### PR TITLE
Modify Makefile to allow setting TOOLBIN, ARCH, TARGET, and DEBUG fro…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,41 +3,41 @@
 default: all
 
 
-#TARGET	= qemu-rv32g
-TARGET	= qemu-rv64g
-#TARGET	= qemu-rv64gc
-#TARGET	= vf2
+#TARGET	?= qemu-rv32g
+TARGET	?= qemu-rv64g
+#TARGET	?= qemu-rv64gc
+#TARGET	?= vf2
 
-DEBUG = -DDEBUG
+DEBUG ?= -DDEBUG
 
 ifeq ($(TARGET), qemu-rv32g)
-	ARCH    	= riscv32-unknown-elf
+	ARCH    	?= riscv32-unknown-elf
 	XLEN		= 32
-	TOOLBIN 	= /opt/riscv/rv32g/bin
+	TOOLBIN 	?= /opt/riscv/rv32g/bin
 	ADDFLAGS	= -DHW_QEMU -DXLEN=$(XLEN) -march=rv32g
 	RUN			= qemu-system-riscv32 -machine virt -cpu rv32,pmp=false -smp 2 -gdb tcp::1234 -bios none -serial stdio -display none -kernel $(BUILD)/$(NAME).img
 endif
 
 ifeq ($(TARGET), qemu-rv64g)
-	ARCH    	= riscv64-unknown-elf
+	ARCH    	?= riscv64-unknown-elf
 	XLEN		= 64
-	TOOLBIN 	= /opt/riscv/rv64g/bin
+	TOOLBIN 	?= /opt/riscv/rv64g/bin
 	ADDFLAGS	= -DHW_QEMU -DXLEN=$(XLEN) -march=rv64g
 	RUN			= qemu-system-riscv64 -machine virt -cpu rv64,pmp=false -smp 2 -gdb tcp::1234 -bios none -serial stdio -display none -kernel $(BUILD)/$(NAME).img
 endif
 
 ifeq ($(TARGET), qemu-rv64gc)
-	ARCH    	= riscv64-unknown-elf
+	ARCH    	?= riscv64-unknown-elf
 	XLEN		= 64
-	TOOLBIN 	= /opt/riscv/rv64g/bin
+	TOOLBIN 	?= /opt/riscv/rv64g/bin
 	ADDFLAGS	= -DHW_QEMU -DXLEN=$(XLEN) -march=rv64gc -mabi=lp64
 	RUN			= qemu-system-riscv64 -machine virt -cpu rv64,pmp=false -smp 2 -gdb tcp::1234 -bios none -serial stdio -display none -kernel $(BUILD)/$(NAME).img
 endif
 
 ifeq ($(TARGET), vf2)
-	ARCH    	= riscv64-unknown-elf
+	ARCH    	?= riscv64-unknown-elf
 	XLEN		= 64
-	TOOLBIN 	= /opt/riscv/rv64g/bin
+	TOOLBIN 	?= /opt/riscv/rv64g/bin
 	ADDFLAGS	= -DHW_VF2 -DXLEN=$(XLEN) -march=rv64g
 define VF2_RUN_MSG
 
@@ -82,7 +82,7 @@ DEP = $(OBJ:%.o=%.d)
 
 all: $(BUILD) $(BUILD)/$(NAME).img $(BUILD)/$(NAME)-stripped.img
 	ls -al $(BUILD)/$(NAME).img $(BUILD)/$(NAME)-stripped.img
-	
+
 $(BUILD):
 	mkdir -p $(BUILD)
 


### PR DESCRIPTION
…m the make command line instead of having to edit the Makefile manually.

For example:

bash> export TOOLBIN=/Applications/Arduino-1.8.13.app/Contents/Java/portable/packages/esp32/tools/riscv32-esp-elf-gcc/gcc8_4_0-esp-2021r1/bin

bash> make TARGET=qemu-rv32g ARCH=riscv32-esp-elf clean rm -f build/qemu-rv32g/*.o build/qemu-rv32g/*.d build/qemu-rv32g/*.elf build/qemu-rv32g/*.img build/qemu-rv32g/*.log build/qemu-rv32g/*.objdump

bash> make TARGET=qemu-rv32g ARCH=riscv32-esp-elf
/Applications/Arduino-1.8.13.app/Contents/Java/portable/packages/esp32/tools/riscv32-esp-elf-gcc/gcc8_4_0-esp-2021r1/bin/riscv32-esp-elf-gcc -DDEBUG -DHW_QEMU -DXLEN=32 -march=rv32g -nostartfiles -g -I"src/include" -MMD -c src/cmd_D.S -o build/qemu-rv32g/cmd_D.o /Applications/Arduino-1.8.13.app/Contents/Java/portable/packages/esp32/tools/riscv32-esp-elf-gcc/gcc8_4_0-esp-2021r1/bin/riscv32-esp-elf-gcc -DDEBUG -DHW_QEMU -DXLEN=32 -march=rv32g -nostartfiles -g -I"src/include" -MMD -c src/cmd_G.S -o build/qemu-rv32g/cmd_G.o
   : etc