### PR TITLE
add .size directives

### DIFF
--- a/src/cmd_D.S
+++ b/src/cmd_D.S
@@ -73,11 +73,15 @@ cmd_D_done:
     la      a0, last_address 
     SAVE_X  s5, 0(a0)
     j       main_prompt
+.size cmd_D, .-cmd_D
  
  
 .data
 string_OP_UNKNOWN:      .string "???";
+.size string_OP_UNKNOWN, .-string_OP_UNKNOWN
+	
 string_line_prefix_D:   .string ",";
+.size string_line_prefix_D, .-string_line_prefix_D
 
 
 #endif /* WITH_CMD_D */

--- a/src/cmd_G.S
+++ b/src/cmd_G.S
@@ -24,9 +24,11 @@ cmd_G_error:
     la      a0, error_no_addr
     jal     print_string
     j       main_prompt
+.size cmd_G, .-cmd_G
 
 
 .data
 string_go:              .string "jumping to address ";
+.size string_go, .-string_go
 
 #endif /* WITH_CMD_G */

--- a/src/cmd_H.S
+++ b/src/cmd_H.S
@@ -12,20 +12,22 @@ cmd_H:
     la      a0, string_help
     jal     print_string
     j       main_prompt
+.size cmd_H, .-cmd_H
 
 
 .data
 string_help:
-.string "\nCommands:  
-    d <start_addr> - disassemble 16 instructions starting at start_addr 
-    d <start_addr> <end_addr> - disassemble from start_addr to end_addr
-    d - continue disassembly from last address
-    g <start_addr> - go to start_addr
-    h - help
-    i - print segment and debugging information
-    m <start_addr> - memory dump 128 bytes starting at start_addr
-    m <start_addr> <end_addr> - memory dump from start_addr to end_addr
-    m - continue memory dump from last address
-    x - exit to caller
-Address entry is in hex (without 0x prefix).\n"
+.string "\nCommands:\n\
+    d <start_addr> - disassemble 16 instructions starting at start_addr\n\
+    d <start_addr> <end_addr> - disassemble from start_addr to end_addr\n\
+    d - continue disassembly from last address\n\
+    g <start_addr> - go to start_addr\n\
+    h - help\n\
+    i - print segment and debugging information\n\
+    m <start_addr> - memory dump 128 bytes starting at start_addr\n\
+    m <start_addr> <end_addr> - memory dump from start_addr to end_addr\n\
+    m - continue memory dump from last address\n\
+    x - exit to caller\n\
+    Address entry is in hex (without 0x prefix).\n"
+.size string_help, .-string_help
 #endif /* WITH_CMD_H */

--- a/src/cmd_I.S
+++ b/src/cmd_I.S
@@ -55,24 +55,33 @@ cmd_I:
 #endif /* WITH_TESTCODE */
 
     j       main_prompt
+.size cmd_I, .-cmd_I
 
 
 .data
 string_info_text:
     .string ".text addr: ";
+.size string_info_text, .-string_info_text
 string_info_data:
     .string "\n.data addr: ";
+.size string_info_data, .-string_info_data
 string_info_bss:
     .string "\n.bss addr: ";
+.size string_info_bss, .-string_info_bss
 string_info_buffer:
     .string "\nbuffer addr: ";
+.size string_info_buffer, .-string_info_buffer
 string_info_stackstart:
     .string "\nstack start addr: ";
+.size string_info_stackstart, .-string_info_stackstart
 string_info_stackend:
     .string "\nstack end addr: ";
+.size string_info_stackend, .-string_info_stackend
 string_info_stacksize:
     .string "\nstack bytes free: ";
+.size string_info_stacksize, .-string_info_stacksize
 string_info_testcode:
     .string "\ntestcode addr: ";
+.size string_info_testcode, .-string_info_testcode
 
 #endif /* WITH_CMD_I */

--- a/src/cmd_M.S
+++ b/src/cmd_M.S
@@ -64,10 +64,12 @@ cmd_M_done:
     la      a0, last_address 
     SAVE_X  s5, 0(a0)
     j       main_prompt
+.size cmd_M, .-cmd_M
 
 
 .data
 string_line_prefix_M:   .string ":";
+.size string_line_prefix_M, .-string_line_prefix_M
 
 
 

--- a/src/cmd_X.S
+++ b/src/cmd_X.S
@@ -31,9 +31,11 @@ cmd_X:
     LOAD_X  sp, (XLEN_BYTES*1)(sp)     
     # return control to caller     
     ret     
+.size cmd_X, .-cmd_X
 
 
 .data
 string_exit:            .string "exiting: ret, ra=";
+.size string_exit, .-string_exit
 
 #endif /* WITH_CMD_X */

--- a/src/decode.S
+++ b/src/decode.S
@@ -42,6 +42,7 @@ insn_get_aqrl:
     and     a1, t0, a1
     srli    a1, a1, 25
     ret
+.size insn_get_aqrl, .-insn_get_aqrl
 
 #endif
 
@@ -88,6 +89,7 @@ decode_B_type:
     LOAD_X  s2, (XLEN_BYTES*1)(sp)               
     addi    sp, sp, (XLEN_BYTES*2)
     ret
+.size decode_B_type, .-decode_B_type
 
 
 # in: instruction word in a0
@@ -113,6 +115,7 @@ decode_I_type:
     LOAD_X  s2, (XLEN_BYTES*1)(sp)               
     addi    sp, sp, (XLEN_BYTES*2)
     ret
+.size decode_I_type, .-decode_I_type
 
 
 # in: instruction word in a0
@@ -141,6 +144,7 @@ decode_I_type_LOAD:
     LOAD_X  s2, (XLEN_BYTES*1)(sp)               
     addi    sp, sp, (XLEN_BYTES*2)
     ret
+.size decode_I_type_LOAD, .-decode_I_type_LOAD
 
 
 # in: instruction word in a0
@@ -165,6 +169,7 @@ decode_I_type_SHIFT:
     LOAD_X  s2, (XLEN_BYTES*1)(sp)               
     addi    sp, sp, (XLEN_BYTES*2)
     ret
+.size decode_I_type_SHIFT, .-decode_I_type_SHIFT
 
 
 # in: instruction word in a0
@@ -183,6 +188,7 @@ decode_R_type:
     LOAD_X  s2, (XLEN_BYTES*1)(sp)               
     addi    sp, sp, (XLEN_BYTES*2)
     ret
+.size decode_R_type, .-decode_R_type
 
 
 # in: instruction word in a0
@@ -223,6 +229,7 @@ decode_S_type:
     LOAD_X  s2, (XLEN_BYTES*1)(sp)               
     addi    sp, sp, (XLEN_BYTES*2)
     ret
+.size decode_S_type, .-decode_S_type
 
 
 # in: instruction word in a0
@@ -239,6 +246,7 @@ decode_U_type:
     LOAD_X  s2, (XLEN_BYTES*1)(sp)               
     addi    sp, sp, (XLEN_BYTES*2)
     ret
+.size decode_U_type, .-decode_U_type
 
 
 # in: instruction word in a0
@@ -279,6 +287,7 @@ decode_JAL:
     LOAD_X  s2, (XLEN_BYTES*1)(sp)               
     addi    sp, sp, (XLEN_BYTES*2)
     ret
+.size decode_JAL, .-decode_JAL
 
 
 # in: instruction word in a0
@@ -308,6 +317,7 @@ decode_JALR:
     LOAD_X  s2, (XLEN_BYTES*1)(sp)               
     addi    sp, sp, (XLEN_BYTES*2)
     ret
+.size decode_JALR, .-decode_JALR
 
 
 decode_FENCE:
@@ -317,6 +327,11 @@ decode_FENCE_I:
 decode_EMPTY:
     # do nothing
     ret
+.size decode_FENCE, .-decode_FENCE
+.size decode_ECALL, .-decode_ECALL
+.size decode_EBREAK, .-decode_EBREAK
+.size decode_FENCE_I, .-decode_FENCE_I
+.size decode_EMPTY, .-decode_EMPTY
 
 
 #ifdef ENABLE_RVA
@@ -338,6 +353,7 @@ decode_LRSC:
     LOAD_X  s2, (XLEN_BYTES*1)(sp)               
     addi    sp, sp, (XLEN_BYTES*2)
     ret
+.size decode_LRSC, .-decode_LRSC
 
 
 # in: instruction word in a0
@@ -362,6 +378,7 @@ decode_AMO:
     addi    sp, sp, (XLEN_BYTES*2)
     ret
 #endif
+.size decode_AMO, .-decode_AMO
 
 
 # in: instruction word in a0
@@ -379,6 +396,7 @@ decode_CSR:
     LOAD_X  s2, (XLEN_BYTES*1)(sp)               
     addi    sp, sp, (XLEN_BYTES*2)
     ret
+.size decode_CSR, .-decode_CSR
 
 
 # in: instruction word in a0
@@ -399,6 +417,7 @@ decode_CSRI:
     LOAD_X  s2, (XLEN_BYTES*1)(sp)               
     addi    sp, sp, (XLEN_BYTES*2)
     ret
+.size decode_CSRI, .-decode_CSRI
 
 
 # in: instruction word in a0
@@ -413,6 +432,7 @@ print_rd:
     LOAD_X  ra, 0(sp)               
     addi    sp, sp, (XLEN_BYTES*1)
     ret
+.size print_rd, .-print_rd
 
 
 # in: instruction word in a0
@@ -425,6 +445,7 @@ print_rs1:
     LOAD_X  ra, 0(sp)               
     addi    sp, sp, (XLEN_BYTES*1)
     ret
+.size print_rs1, .-print_rs1
 
 
 # in: instruction word in a0
@@ -437,6 +458,7 @@ print_rs2:
     LOAD_X  ra, 0(sp)               
     addi    sp, sp, (XLEN_BYTES*1)
     ret
+.size print_rs2, .-print_rs2
 
 
 # in: instruction word in a0
@@ -449,6 +471,7 @@ print_csr:
     LOAD_X  ra, 0(sp)               
     addi    sp, sp, (XLEN_BYTES*1)
     ret
+.size print_csr, .-print_csr
 
 
 # output the n-th register name from the register name table
@@ -477,6 +500,7 @@ print_register_next_zero:
     LOAD_X  s0, (XLEN_BYTES*1)(sp)               
     addi    sp, sp, (XLEN_BYTES*2)
     ret
+.size print_register_name, .-print_register_name
 
 
 # in: instruction word in a0
@@ -521,6 +545,7 @@ decode_opcode_done:
     LOAD_X  ra, 0(sp)               
     addi    sp, sp, (XLEN_BYTES*1)
     ret
+.size decode_opcode, .-decode_opcode
 
 
 # in: instruction word in a0
@@ -551,6 +576,7 @@ print_instruction_done:
     LOAD_X  s3, (XLEN_BYTES*2)(sp)     
     addi    sp, sp, (XLEN_BYTES*3)
     ret
+.size print_instruction, .-print_instruction
 
 
 #ifdef ENABLE_RVA
@@ -585,6 +611,7 @@ print_AMO_postfix_done:
     LOAD_X  ra, 0(sp)               
     addi    sp, sp, (XLEN_BYTES*1)
     ret
+.size print_AMO_postfix, .-print_AMO_postfix
 
 #endif
 
@@ -595,8 +622,11 @@ print_AMO_postfix_done:
 #ifdef ENABLE_RVA
 .align 4
 string_OP_POSTFIX_AQ:   .string ".aq";
+.size string_OP_POSTFIX_AQ, .-string_OP_POSTFIX_AQ
 string_OP_POSTFIX_RL:	.string ".rl";
+.size string_OP_POSTFIX_RL, .-string_OP_POSTFIX_RL
 string_OP_POSTFIX_AQRL:	.string ".aqrl";
+.size string_OP_POSTFIX_AQRL, .-string_OP_POSTFIX_AQRL
 #endif
 
 

--- a/src/encoding.S
+++ b/src/encoding.S
@@ -22,12 +22,14 @@ register_names:
 	.string "a6",   "a7",  "s2",  "s3", "s4", "s5", "s6", "s7"
 	.string "s8",   "s9", "s10", "s11", "t3", "t4", "t5", "t6"
 #endif
+.size register_names, .-register_names
 
 
 # Opcode strings
 
 
 # RV32I
+string_opcodes:
 string_OP_LUI:      .string "lui";		#
 string_OP_AUIPC:    .string "auipc";	#	
 string_OP_JAL:      .string "jal";		#
@@ -161,6 +163,7 @@ string_OP_CSRRCI:	.string "csrrci";	#
 	string_OP_RET:		.string "ret";	
 	string_OP_NOP:		.string "nop";	
 #endif /* ENABLE_PSEUDO */
+.size string_opcodes, .-string_opcodes
 
 
 .align 4
@@ -299,5 +302,6 @@ encoding_table:
 
 # table end marker
 .word 0, 0, 0, 0
+.size encoding_table, .-encoding_table
 
 #endif /* WITH_CMD_D */

--- a/src/error.S
+++ b/src/error.S
@@ -7,5 +7,7 @@
 
 .data
 error_no_addr:          .string "ERROR: address invalid";
+.size error_no_addr, .-error_no_addr
 error_unknown_command:	.string "ERROR: unknown command";
+.size error_unknown_command, .-error_unknown_command
 

--- a/src/main.S
+++ b/src/main.S
@@ -133,6 +133,7 @@ get_command:
     mv      s4, a0
     # take first non-whitespace char in line as command
     lb      t1, 0(s4)               # get byte from buffer
+.size start, .-start
 
 #ifdef WITH_CMD_D
     li      t0, 'd'
@@ -193,25 +194,34 @@ main_clear_buffer_loop:
     addi    t0, t0, 4
     ble     t0, t1, main_clear_buffer_loop
     ret
+.size main_clear_buffer, .-main_clear_buffer
 
 
 .data
 start_data:
 
 string_startup:     .string "\nVMON - RISC-V machine code monitor";
+.size string_startup, .-string_startup
 string_prompt:      .string "\n.";
+.size string_prompt, .-string_prompt
 
 string_asm_sep1:    .string ":";
+.size string_asm_sep1, .-string_asm_sep1
 string_asm_sep2:    .string "\t";
+.size string_asm_sep2, .-string_asm_sep2
 string_asm_comment: .string "\t# ";
+.size string_asm_comment, .-string_asm_comment
 
 .bss
 start_bss:
 .align 8
 .comm last_address, XLEN_BYTES  # last address used in m or d command
-
+.size last_address, XLEN_BYTES
+	
 .align 8
 .comm buffer, BUFFER_SIZE       # for command line input
-
+.size buffer, BUFFER_SIZE
+        
 .align 8
 .comm stack, STACK_SIZE         # our execution stack
+.size stack, STACK_SIZE

--- a/src/math.S
+++ b/src/math.S
@@ -37,6 +37,7 @@ divrem2:
 	srli	bit, bit, 1
 	bnez	bit, divrem1
 	ret
+.size divrem, .-divrem
 
 	#undef Q
 	#undef R

--- a/src/parse.S
+++ b/src/parse.S
@@ -19,6 +19,7 @@ skip_whitespace_next_byte:
     beq     t2, t0, skip_whitespace_next_byte 
     beq     t2, t1, skip_whitespace_next_byte 
     ret
+.size skip_whitespace, .-skip_whitespace
 
 
 # in: buffer ptr in a0
@@ -61,3 +62,4 @@ get_hex_addr_check_alpha:
     li      a2, -1
  get_hex_addr_return:   
     ret	
+.size get_hex_addr, .-get_hex_addr

--- a/src/print.S
+++ b/src/print.S
@@ -27,6 +27,7 @@ print_comma:
     LOAD_X  ra, 0(sp)             
     addi    sp, sp, (XLEN_BYTES*1)
     ret
+.size print_comma, .-print_comma
 
 
 print_hex_prefix:
@@ -39,6 +40,7 @@ print_hex_prefix:
     LOAD_X  ra, 0(sp)             
     addi    sp, sp, (XLEN_BYTES*1)
     ret
+.size print_hex_prefix, .-print_hex_prefix
 
 
 # in: print value in a0 in hex with "0x" prefix
@@ -50,6 +52,7 @@ print_hex:
     LOAD_X  ra, 0(sp)                       
     addi    sp, sp, (XLEN_BYTES*1)
     ret
+.size print_hex, .-print_hex
 
 
 # in: print value in a0 in hex
@@ -81,6 +84,7 @@ print_hex_new_decimal:
     LOAD_X  ra, 0(sp)             
     addi    sp, sp, (XLEN_BYTES*1)
     ret
+.size print_hex_raw, .-print_hex_raw
 
 
 # print a 2-digit hex value (with leading zero for 1-digit values)
@@ -100,6 +104,7 @@ print_hex_byte_two_digits:
     LOAD_X  ra, 0(sp)             
     addi    sp, sp, (XLEN_BYTES*1)
     ret
+.size print_hex_byte, .-print_hex_byte
 
 
 # print char in a0 to terminal (if printable, else '.')
@@ -119,6 +124,7 @@ print_ascii_out:
     LOAD_X  ra, 0(sp)             
     addi    sp, sp, (XLEN_BYTES*1)
     ret
+.size print_ascii, .-print_ascii
 
 
 # print ASCII char in a0
@@ -129,6 +135,7 @@ print_char:
     LOAD_X  ra, 0(sp)             
     addi    sp, sp, (XLEN_BYTES*1)
     ret
+.size print_char, .-print_char
 
 
 # print string starting at addr in a0
@@ -139,6 +146,7 @@ print_string:
     LOAD_X  ra, 0(sp)             
     addi    sp, sp, (XLEN_BYTES*1)
     ret
+.size print_string, .-print_string
 
 
 #ifdef WITH_CMD_D
@@ -188,6 +196,7 @@ print_decimal_done:
     LOAD_X  s2, (XLEN_BYTES*1)(sp)               
     addi    sp, sp, (XLEN_BYTES*2)
     ret
+.size print_decimal, .-print_decimal
 
 
 #endif /* WITH_CMD_D */
@@ -197,6 +206,8 @@ print_decimal_done:
 .align 8
 
 .comm dec_buf, DEC_BUFFER_SIZE
+.size dec_buf, DEC_BUFFER_SIZE
 
 .comm out_buf, OUT_BUFFER_SIZE
+.size out_buf, OUT_BUFFER_SIZE
 

--- a/src/testcode.S
+++ b/src/testcode.S
@@ -464,6 +464,7 @@ testcode_jal_forward:
     c.sub       s0, s1
 */
 #endif /* ENABLE_RVC */
+.size testcode, .-testcode
 
 
 

--- a/src/uart.S
+++ b/src/uart.S
@@ -15,6 +15,7 @@ uart_init:
     li      t0, UART_MODE_8N1
     sb      t0, UART_REG_LSR(t1)      
     ret
+.size uart_init, .-uart_init
 
 
 # wait and get one character from UART 
@@ -29,6 +30,7 @@ uart_get_char_wait:
     beqz    a0, uart_get_char_wait      # wait for char input
     lbu     a0, 0(t0)                   # get input from UART  
     ret
+.size uart_wait_get_char, .-uart_wait_get_char
 
 
 # output one char 
@@ -43,6 +45,7 @@ uart_output_char:
     LOAD_X  ra, 0(sp)             
     addi    sp, sp, (XLEN_BYTES*1)
     ret
+.size uart_output_char, .-uart_output_char
 
 
 # output zero-terminated string  
@@ -61,6 +64,7 @@ uart_output_string_done:
     LOAD_X  ra, 0(sp)             
     addi    sp, sp, (XLEN_BYTES*1)
     ret
+.size uart_output_string, .-uart_output_string
 
 
 # print zero-terminated string in output buffer out_buf to UART
@@ -90,3 +94,4 @@ uart_output_buffer_done:
     LOAD_X  ra, 0(sp)             
     addi    sp, sp, (XLEN_BYTES*1)
     ret
+.size uart_output_buffer, .-uart_output_buffer


### PR DESCRIPTION
The .size directives enable looking at the .elf file with "nm" and similar tools to judge which functions are large and might deserve optimization.
(Note that this isn't perfect, mostly because of the way the individual commands are implemented as inline code rather than functions.  so the length of "start" and "main_prompt" includes the sum of all the cmd_xxx code.)
(This should not affect the binary code at all.  .size adds to the debug information in the .elf file.)

Also, "fix" the multi-line string in cmd_H.S to prevent assembler warnings.
(Hmm.  I notice that "\n" is being used as a line terminator.  Should this be "\r\n", especially for real hardware?)
