### PR TITLE
Fix target names

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,16 +84,16 @@ DEP = $(OBJ:%.o=%.d)
 
 
 #targets
-all: $(BUILD) $(BUILD)/$(NAME).img $(BUILD)/$(NAME)-stripped.img
-	ls -al $(BUILD)/$(NAME).img $(BUILD)/$(NAME)-stripped.img
+all: $(BUILD) $(BUILD)/$(NAME).img $(BUILD)/$(NAME)-stripped.elf
+	ls -al $(BUILD)/$(NAME).img $(BUILD)/$(NAME)-stripped.elf
 
 $(BUILD):
 	mkdir -p $(BUILD)
 
 $(BUILD)/$(NAME).img: $(BUILD)/$(NAME).elf
-	$(OBJCOPY) $(BUILD)/$(NAME).elf -I binary $@
+	$(OBJCOPY) $(BUILD)/$(NAME).elf -O binary $@
 
-$(BUILD)/$(NAME)-stripped.img: $(BUILD)/$(NAME).img
+$(BUILD)/$(NAME)-stripped.elf: $(BUILD)/$(NAME).elf
 	$(STRIP) $< -o $@
 
 $(BUILD)/$(NAME).elf: linker/link.ld.$(PLATFORM) Makefile $(OBJ)


### PR DESCRIPTION
Previously vmon.img was the same file as vmon.elf, and the stripped file was also named .img despite being an elf.  Here we make vmon-stripped be given the .elf extension, and the only vmon.img is a flat binary.

If this wasnʼt your intent, I donʼt know what you *did* intend, but I expect it wasnʼt quite what you have now.