### PR TITLE
Improve newline support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,6 @@ define VF2_RUN_MSG
 	- copy build/vf2/vmon.img to SD card
 	- insert SD card into VF2
 	- attach GPIO-to-USB serial terminal to VF2 (e.g. minicom, 115200 baud)
-	- set minicom to "Add Carriage Ret" (Ctrl-A Z, then U)
 	- boot into U-Boot from SPI (both dip-switches to L)
 	- in U-Boot command line, load and run vmon.img:
 	StarFive # fatload mmc 1:2  0x43fff000 vmon.img

--- a/src/cmd_A.S
+++ b/src/cmd_A.S
@@ -29,11 +29,7 @@ cmd_A_input_loop:
 	# get one line of asembly input (until ASCII_RETURN)
 	jal		uart_getline
 	#  buffer start in a0
-	mv		s2, a0					# save for later
-	li      a0, ASCII_NEWLINE
-    jal     print_char
 	# exit loop if line was empty
-	mv		a0, s2
 	jal		skip_whitespace
 	lb		t0, 0(a0)
 	li		t1, ASCII_RETURN

--- a/src/cmd_D.S
+++ b/src/cmd_D.S
@@ -79,8 +79,7 @@ cmd_D_advance:
     addi    s5, s5, 2                   # add 2 more bytes if not compressed
 cmd_D_advance_done:
     bgt     s5, s7, cmd_D_done          # check if end address reached
-    li      a0, ASCII_NEWLINE
-    jal     print_char
+    jal     print_newline
     j       cmd_D_next_instruction
 cmd_D_done:
     la      a0, last_address 

--- a/src/cmd_M.S
+++ b/src/cmd_M.S
@@ -55,8 +55,7 @@ cmd_M_next_char:
     j       cmd_M_next_char
 cmd_M_ascii_done:
     bgt     s5, s7, cmd_M_done
-    li      a0, ASCII_NEWLINE
-    jal     print_char
+    jal     print_newline
     j       cmd_M_next_line
 cmd_M_done:
     la      a0, last_address 

--- a/src/include/vmon/config.h
+++ b/src/include/vmon/config.h
@@ -84,6 +84,11 @@
 // print a space after commas in disassembler output
 #define SPACE_AFTER_COMMA
 
+// print a CR before each LF
+// Note: at higher levels this varies by system but at this level most
+// things expect both.
+#define USE_CRLF
+
 // size of character input buffer in bytes
 #define BUFFER_SIZE			128
 

--- a/src/include/vmon/config.h
+++ b/src/include/vmon/config.h
@@ -75,6 +75,9 @@
 // enable printing of pseudo opcodes in disassembly?
 #define ENABLE_PSEUDO
 
+// include strings for MCAUSE verbose output?
+#define MCAUSE_VERBOSE
+
 // default number of lines for the "d" command if no end address is given
 #define	DEFAULT_D_LINES		16
 

--- a/src/main.S
+++ b/src/main.S
@@ -102,8 +102,7 @@ start:
 
     # main loop
 main_prompt:
-    li      a0, ASCII_NEWLINE
-    jal     print_char
+    jal     print_newline
 
 main_prompt_no_newline:
     la      a0, string_prompt

--- a/src/main.S
+++ b/src/main.S
@@ -110,12 +110,6 @@ main_prompt_no_newline:
     jal     print_string
 
     jal     uart_getline
-    mv      s2, a0
-
-    li      a0, ASCII_NEWLINE
-    jal     print_char
-    
-    mv      a0, s2
     jal     skip_whitespace
     
     lb      t1, 0(a0)

--- a/src/print.S
+++ b/src/print.S
@@ -1,4 +1,5 @@
 #include "vmon/config.h"
+#include "vmon/ASCII.h"
 
 
 .global print_hex
@@ -9,6 +10,7 @@
 .global print_string
 .global print_decimal
 .global print_comma
+.global print_newline
 .global out_buf
 
 
@@ -30,6 +32,20 @@ print_comma:
     addi    sp, sp, (XLEN_BYTES*1)
     ret
 .size print_comma, .-print_comma
+
+print_newline:
+    addi    sp, sp, -(XLEN_BYTES*1)
+    SAVE_X  ra, 0(sp)
+#ifdef USE_CRLF
+    li      a0, ASCII_RETURN
+    jal     print_char
+#endif
+    li      a0, ASCII_NEWLINE
+    jal     print_char
+    LOAD_X  ra, 0(sp)
+    addi    sp, sp, (XLEN_BYTES*1)
+    ret
+.size print_newline, .-print_newline
 
 
 # in: print value in a0 in hex with "0x" prefix

--- a/src/trap.S
+++ b/src/trap.S
@@ -41,11 +41,12 @@ setup_trap_handler:
 
 trap_handler:
 	# push stack
-    addi    sp, sp, -(XLEN_BYTES*4)              
+    addi    sp, sp, -(XLEN_BYTES*5)              
     SAVE_X  ra, 0(sp)
     SAVE_X  a0, (XLEN_BYTES*1)(sp)
     SAVE_X  t0, (XLEN_BYTES*2)(sp)
     SAVE_X  t1, (XLEN_BYTES*3)(sp)
+    SAVE_X  s0, (XLEN_BYTES*4)(sp)
 	# clear irq
 	li 		t0, 0b10000000
 	csrc	mip, t0
@@ -64,11 +65,33 @@ trap_handler_exception:
 	la		a0, string_exception_msg
 	jal		print_string
 	csrr	a0, mcause
+	mv		s0, a0								# save for later
 	jal		print_hex
+
+	# print MCAUSE verbose
+#ifdef MCAUSE_VERBOSE
+	li		a0, ' '
+	jal		print_char
+	li		a0, '('
+	jal		print_char
+	# each entry in MCAUSE string table is 4 bytes
+	slli	a0, s0, 2							# set a0 = mcause * 4
+	la		s0, mcause_verbose_table			# start of MCAUSE string table
+	add		a0, a0, s0
+#if XLEN >= 64
+	lwu		a0, 0(a0)
+#else
+	lw		a0, 0(a0)
+#endif
+	jal 	print_string
+	li		a0, ')'
+	jal		print_char
+#endif
+
 	# set return address for leaving trap handler
 	la		a0, main_prompt
 	csrw	mepc, a0
-	# reset stack to the value that should have at main_prompt
+	# reset stack to the value that it should have at main_prompt
 	la		a0, stackptr_reset
 	LOAD_X	sp, 0(a0)
 	mret
@@ -83,11 +106,12 @@ trap_handler_irq:
 	SAVE_X	t1, 0(t0)
 trap_handler_pop:
 	# pop stack
-	LOAD_X  ra, 0(sp)               
-    LOAD_X  a0, (XLEN_BYTES*1)(sp)               
-    LOAD_X  t0, (XLEN_BYTES*2)(sp)               
-    LOAD_X  t1, (XLEN_BYTES*3)(sp)               
-    addi    sp, sp, (XLEN_BYTES*4)
+	LOAD_X  ra, 0(sp)
+	LOAD_X  a0, (XLEN_BYTES*1)(sp)
+	LOAD_X  t0, (XLEN_BYTES*2)(sp)
+	LOAD_X  t1, (XLEN_BYTES*3)(sp)
+	LOAD_X  s0, (XLEN_BYTES*4)(sp)
+	addi    sp, sp, (XLEN_BYTES*5)
 	mret
 .size trap_handler, .-trap_handler
 
@@ -95,8 +119,39 @@ trap_handler_pop:
 .data
 
 .align 4
-
 string_exception_msg:		.string "\nexception: mcause=";
+
+#ifdef MCAUSE_VERBOSE
+.align 4
+string_CAUSE_MISALIGNED_FETCH:		.string "CAUSE_MISALIGNED_FETCH";
+string_CAUSE_FAULT_FETCH:			.string "CAUSE_FAULT_FETCH";
+string_CAUSE_ILLEGAL_INSTRUCTION:	.string "CAUSE_ILLEGAL_INSTRUCTION";
+string_CAUSE_BREAKPOINT:			.string "CAUSE_BREAKPOINT";
+string_CAUSE_MISALIGNED_LOAD:		.string "CAUSE_MISALIGNED_LOAD";
+string_CAUSE_FAULT_LOAD:			.string "CAUSE_FAULT_LOAD";
+string_CAUSE_MISALIGNED_STORE:		.string "CAUSE_MISALIGNED_STORE";
+string_CAUSE_FAULT_STORE:			.string "CAUSE_FAULT_STORE";
+string_CAUSE_USER_ECALL:			.string "CAUSE_USER_ECALL";
+string_CAUSE_SUPERVISOR_ECALL:		.string "CAUSE_SUPERVISOR_ECALL";
+string_CAUSE_HYPERVISOR_ECALL:		.string "CAUSE_HYPERVISOR_ECALL";
+string_CAUSE_MACHINE_ECALL:			.string "CAUSE_MACHINE_ECALL";
+
+.align 4
+mcause_verbose_table:
+.word string_CAUSE_MISALIGNED_FETCH
+.word string_CAUSE_FAULT_FETCH
+.word string_CAUSE_ILLEGAL_INSTRUCTION
+.word string_CAUSE_BREAKPOINT
+.word string_CAUSE_MISALIGNED_LOAD
+.word string_CAUSE_FAULT_LOAD
+.word string_CAUSE_MISALIGNED_STORE
+.word string_CAUSE_FAULT_STORE
+.word string_CAUSE_USER_ECALL
+.word string_CAUSE_SUPERVISOR_ECALL
+.word string_CAUSE_HYPERVISOR_ECALL
+.word string_CAUSE_MACHINE_ECALL
+#endif 
+
 
 .bss
 .align 8

--- a/src/uart.S
+++ b/src/uart.S
@@ -162,6 +162,9 @@ uart_continue_not_delete:
     j       uart_get_char      
 
 uart_getline_done:
+    # print LF to follow read CR
+    li a0, ASCII_NEWLINE
+    jal uart_output_char
     # return buffer address
     mv      a0, s1
 

--- a/src/uart.S
+++ b/src/uart.S
@@ -1,3 +1,4 @@
+#include "vmon/ASCII.h"
 #include "vmon/config.h"
 #include "vmon/drivers/uart/ns16550.h"
 #include "vmon/ASCII.h"
@@ -71,6 +72,14 @@ uart_output_string:
 uart_output_string_loop:
     lb      a0, 0(a1)
     beqz    a0, uart_output_string_done
+#ifdef USE_CRLF
+    li      t0, ASCII_NEWLINE
+    bne     a0, t0, uart_output_string_char
+    li      a0, ASCII_RETURN  # First output CR
+    jal     uart_output_char
+    li      a0, ASCII_NEWLINE # Put LF back in a0
+uart_output_string_char:
+#endif
     jal     uart_output_char
     addi    a1, a1, 1
     j       uart_output_string_loop

--- a/src/uart.S
+++ b/src/uart.S
@@ -147,16 +147,16 @@ uart_input_is_delete:
     addi    s0, s0, -1
     # ASCII output
     li      a0, ASCII_BACKSPACE
-    jal     print_char
+    jal     uart_output_char
     li      a0, ' '
-    jal     print_char
+    jal     uart_output_char
     li      a0, ASCII_BACKSPACE
-    jal     print_char
+    jal     uart_output_char
     j       uart_get_char  
 
 uart_continue_not_delete:
     # output char in a0
-    jal     print_char
+    jal     uart_output_char
     li      t0, ASCII_RETURN        
     beq     a0, t0, uart_getline_done
     j       uart_get_char      


### PR DESCRIPTION
I make a couple changes to the `uart_get_line` function but mostly this changes how newline printing is done.  Most systems expect that output will be CRLF; if you just do an LF itʼll do a stairstep-type pattern:
![image](https://github.com/user-attachments/assets/6ffdae88-cee8-4468-b763-29e52a39549a)

QEMU seems to be the exception, which I assume is why this wasnʼt already implemented, but itʼs only *sometimes* an exception.  When using the `stdio` output method, tells the kernel to do the post-processing of adding a CR before LF, and it defaults to that mode when run with `-nographic`.  I considered wrapping the `#define USE_CRLF` in an `#ifndef HW_QEMU` because of this, but decided against it, because QEMU has lots of output options and the extra CR doesnʼt do any *harm* when using the `stdio` one.

Note that I have not tested on VF2 hardware, but I would strongly expect that my change of instructions there does work; that line was specifically for working around this issue.