### PR TITLE
Format assembly source files with 4-space tabs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,3 +114,6 @@ device-tree:
 	qemu-system-riscv$(XLEN) $(QEMU_FLAGS) -machine dumpdtb=$(BUILD)/qemu.dtb
 	dtc -I dtb -O dts $(BUILD)/qemu.dtb -o $(BUILD)/qemu-device-tree.dts
 	less $(BUILD)/qemu-device-tree.dts
+
+format:
+	./vmon-format.sh src/*.S

--- a/src/assemble.S
+++ b/src/assemble.S
@@ -1,135 +1,135 @@
-#include "vmon/config.h"
-#include "vmon/ASCII.h"
+	#include "vmon/config.h"
+	#include "vmon/ASCII.h"
 
-#ifdef WITH_CMD_A
+	#ifdef WITH_CMD_A
 
-.global assemble_instruction
+	.global assemble_instruction
 
-.global assemble_DUMMY
-.global assemble_VOID
-.global assemble_BRANCH
+	.global assemble_DUMMY
+	.global assemble_VOID
+	.global assemble_BRANCH
 
 
-.text
+	.text
 
-# in: a0 = ptr to input text
-# out: a0 = number of bytes written to memory (normal 4, 2 for RVC, 0 if error)
-# out: a1 = assembled instruction to be written into memory
+	# in: a0 = ptr to input text
+	# out: a0 = number of bytes written to memory (normal 4, 2 for RVC, 0 if error)
+	# out: a1 = assembled instruction to be written into memory
 assemble_instruction:  
-    addi    sp, sp, -(XLEN_BYTES*3)              
-    SAVE_X  ra, 0(sp)
-    SAVE_X  s0, (XLEN_BYTES*1)(sp)
-    SAVE_X  s1, (XLEN_BYTES*2)(sp)
-    jal     skip_whitespace
-    mv      s0, a0
-    jal     find_insn_name_end
-    mv      s1, a0
-    # find string between s0 and s1 in encoding table
-    jal     find_insn_in_table
-    # function ptr now in a0
-    beqz    a0, assemble_instruction_done       # not found
-    jalr    a0                                  # call assemble function   
-    beqz    a0, assemble_instruction_done       # error while assembling insn parameters
-    # now use a0 to return insn size
-    mv      a0, a1    
-#ifdef ENABLE_RVC
-    jal     insn_is_compressed
-    bnez    a0, assemble_instruction_is_RVC
-    li      a0, 4
-    j       assemble_instruction_done
+	addi	sp, sp, -(XLEN_BYTES*3)				 
+	SAVE_X	ra, 0(sp)
+	SAVE_X	s0, (XLEN_BYTES*1)(sp)
+	SAVE_X	s1, (XLEN_BYTES*2)(sp)
+	jal		skip_whitespace
+	mv		s0, a0
+	jal		find_insn_name_end
+	mv		s1, a0
+	# find string between s0 and s1 in encoding table
+	jal		find_insn_in_table
+	# function ptr now in a0
+	beqz	a0, assemble_instruction_done		# not found
+	jalr	a0									# call assemble function   
+	beqz	a0, assemble_instruction_done		# error while assembling insn parameters
+	# now use a0 to return insn size
+	mv		a0, a1	  
+	#ifdef ENABLE_RVC
+	jal		insn_is_compressed
+	bnez	a0, assemble_instruction_is_RVC
+	li		a0, 4
+	j		assemble_instruction_done
 assemble_instruction_is_RVC:
-    li      a0, 2
-#else
-    li      a0, 4
-#endif
+	li		a0, 2
+	#else
+	li		a0, 4
+	#endif
 assemble_instruction_done:
-	LOAD_X  ra, 0(sp)               
-    LOAD_X  s0, (XLEN_BYTES*1)(sp)               
-    LOAD_X  s1, (XLEN_BYTES*2)(sp)               
-    addi    sp, sp, (XLEN_BYTES*3)
-    ret
-.size assemble_instruction, .-assemble_instruction
+	LOAD_X	ra, 0(sp)				
+	LOAD_X	s0, (XLEN_BYTES*1)(sp)				 
+	LOAD_X	s1, (XLEN_BYTES*2)(sp)				 
+	addi	sp, sp, (XLEN_BYTES*3)
+	ret
+	.size assemble_instruction, .-assemble_instruction
 
 
-# in: input string ptr start in s0
-# in: input string ptr end+1 in s1
-# out: ptr to assemble function in a0 (0 if string was not found)
-# out: MATCH value for insn in a1 (undefined if string was not found)
+	# in: input string ptr start in s0
+	# in: input string ptr end+1 in s1
+	# out: ptr to assemble function in a0 (0 if string was not found)
+	# out: MATCH value for insn in a1 (undefined if string was not found)
 find_insn_in_table:
-    la      t0, encoding_table
+	la		t0, encoding_table
 find_insn_in_table_next:
-#if XLEN >= 64
-    lwu     t1, 12(t0)                       # get string ptr from table
-    lwu     a0, 16(t0)                       # get function ptr from table
-#else
-    lw      t1, 12(t0)                       # get string ptr from table
-    lw      a0, 16(t0)                       # get function ptr from table
-#endif
-    beqz    t1, find_insn_in_table_not_found          # table end, no match found
-    # compare strings
-    mv      t2, s0                          # iterate with t2 over input string                         
+	#if XLEN >= 64
+	lwu		t1, 12(t0)						 # get string ptr from table
+	lwu		a0, 16(t0)						 # get function ptr from table
+	#else
+	lw		t1, 12(t0)						 # get string ptr from table
+	lw		a0, 16(t0)						 # get function ptr from table
+	#endif
+	beqz	t1, find_insn_in_table_not_found		  # table end, no match found
+	# compare strings
+	mv		t2, s0							# iterate with t2 over input string							
 find_insn_in_table_cmp_next_byte:
-    beq     t2, s1, find_insn_in_table_done
-    lb      t3, 0(t2)
-    lb      t4, 0(t1)
-    bne     t3, t4, find_insn_in_table_next_entry       # strings not equal
-    beqz    t4, find_insn_in_table_next_entry           # string in table ended
-    addi    t1, t1, 1
-    addi    t2, t2, 1
-    j       find_insn_in_table_cmp_next_byte
+	beq		t2, s1, find_insn_in_table_done
+	lb		t3, 0(t2)
+	lb		t4, 0(t1)
+	bne		t3, t4, find_insn_in_table_next_entry		# strings not equal
+	beqz	t4, find_insn_in_table_next_entry			# string in table ended
+	addi	t1, t1, 1
+	addi	t2, t2, 1
+	j		find_insn_in_table_cmp_next_byte
 find_insn_in_table_next_entry:
-    addi    t0, t0, 20
-    j       find_insn_in_table_next
+	addi	t0, t0, 20
+	j		find_insn_in_table_next
 find_insn_in_table_not_found:
-    mv      a0, zero
+	mv		a0, zero
 find_insn_in_table_done:
-    lw      a1, 4(t0)                       # store MATCH value from table entry in a1
-    ret
-.size find_insn_in_table, .-find_insn_in_table
+	lw		a1, 4(t0)						# store MATCH value from table entry in a1
+	ret
+	.size find_insn_in_table, .-find_insn_in_table
 
 
-# in: input string ptr in a0
-# out: register number in a1 (-1 if error)
+	# in: input string ptr in a0
+	# out: register number in a1 (-1 if error)
 assemble_rs1:
-    ret
-.size assemble_rs1, .-assemble_rs1
+	ret
+	.size assemble_rs1, .-assemble_rs1
 
-    
-# in: input string ptr in a0
+	
+	# in: input string ptr in a0
 assemble_DUMMY:
-    li      a1, 0xffffffff
-    ret
-.size assemble_DUMMY, .-assemble_DUMMY
+	li		a1, 0xffffffff
+	ret
+	.size assemble_DUMMY, .-assemble_DUMMY
 
 
-# in: input string ptr in a0
-# in: MATCH value in a1
+	# in: input string ptr in a0
+	# in: MATCH value in a1
 assemble_VOID:
-    # nothing to be done, a1 already contains final insn
-    ret
-.size assemble_VOID, .-assemble_VOID
+	# nothing to be done, a1 already contains final insn
+	ret
+	.size assemble_VOID, .-assemble_VOID
 
 
-# in: input string ptr in a0
-# in: MATCH value in a1
+	# in: input string ptr in a0
+	# in: MATCH value in a1
 assemble_BRANCH:
-    # read rs1
-    jal     skip_whitespace
+	# read rs1
+	jal		skip_whitespace
 
-    # read comma
-    jal     skip_whitespace
+	# read comma
+	jal		skip_whitespace
 
-    # read rs2
-    jal     skip_whitespace
+	# read rs2
+	jal		skip_whitespace
 
-    # read comma
-    jal     skip_whitespace
+	# read comma
+	jal		skip_whitespace
 
-    # read address
-    jal     skip_whitespace
+	# read address
+	jal		skip_whitespace
 
-    ret
-.size assemble_BRANCH, .-assemble_BRANCH
+	ret
+	.size assemble_BRANCH, .-assemble_BRANCH
 
 
-#endif /* WITH_CMD_A */
+	#endif /* WITH_CMD_A */

--- a/src/cmd_A.S
+++ b/src/cmd_A.S
@@ -1,31 +1,31 @@
-#include "vmon/config.h"
-#include "vmon/ASCII.h"
+	#include "vmon/config.h"
+	#include "vmon/ASCII.h"
 
 
-#ifdef WITH_CMD_A
+	#ifdef WITH_CMD_A
 
-.global cmd_A
+	.global cmd_A
 
-.text
+	.text
 
 
 cmd_A:
 	# read dst_start from text buffer	
-    jal     skip_whitespace
-    jal     get_hex_addr            # read dst_start from text buffer
-    bnez    a2, cmd_A_error         # abort command if not found
+	jal		skip_whitespace
+	jal		get_hex_addr			# read dst_start from text buffer
+	bnez	a2, cmd_A_error			# abort command if not found
 	mv		s0, a1
 
 cmd_A_input_loop:
 	# print line prefix
-    la      a0, string_line_prefix_A
-    jal     print_string
+	la		a0, string_line_prefix_A
+	jal		print_string
 	# print current dst_address
-	mv      a0, s0
-    jal     print_hex
+	mv		a0, s0
+	jal		print_hex
 	# print assembly input prompt
-    la      a0, string_ass_prompt
-    jal     print_string
+	la		a0, string_ass_prompt
+	jal		print_string
 	# get one line of asembly input (until ASCII_RETURN)
 	jal		uart_getline
 	#  buffer start in a0
@@ -39,9 +39,9 @@ cmd_A_input_loop:
 	bnez	a0, cmd_A_continue
 
 	# user entered garbage in assembly line
-    la      a0, string_ass_error
-    jal     print_string
-	j 		cmd_A_input_loop
+	la		a0, string_ass_error
+	jal		print_string
+	j		cmd_A_input_loop
 
 cmd_A_continue:
 	# instruction now in a1
@@ -52,22 +52,22 @@ cmd_A_continue:
 	j		cmd_A_input_loop
 
 cmd_A_error:
-    la      a0, error_param
-    jal     print_string
+	la		a0, error_param
+	jal		print_string
 cmd_A_done:
-    j       main_prompt
-.size cmd_A, .-cmd_A
+	j		main_prompt
+	.size cmd_A, .-cmd_A
 
 
-.data
+	.data
 
-string_line_prefix_A:   .string "A ";
-.size string_line_prefix_A, .-string_line_prefix_A
+string_line_prefix_A:	.string "A ";
+	.size string_line_prefix_A, .-string_line_prefix_A
 
 string_ass_prompt:	.string " := ";
-.size string_ass_prompt, .-string_ass_prompt
+	.size string_ass_prompt, .-string_ass_prompt
 
 string_ass_error:	.string "\t\t???\n\r";
-.size string_ass_error, .-string_ass_error
+	.size string_ass_error, .-string_ass_error
 
-#endif /* WITH_CMD_A */
+	#endif /* WITH_CMD_A */

--- a/src/cmd_C.S
+++ b/src/cmd_C.S
@@ -1,29 +1,29 @@
-#include "vmon/config.h"
+	#include "vmon/config.h"
 
 
-#ifdef WITH_CMD_C
+	#ifdef WITH_CMD_C
 
-.global cmd_C
+	.global cmd_C
 
-.text
+	.text
 
 
 cmd_C:
 	# read src_start from text buffer	
-    jal     skip_whitespace
-    jal     get_hex_addr            # read src_start from text buffer
-    bnez    a2, cmd_C_error         # abort command if not found
+	jal		skip_whitespace
+	jal		get_hex_addr			# read src_start from text buffer
+	bnez	a2, cmd_C_error			# abort command if not found
 	mv		a3, a1
 	# read src_end from text buffer
-	jal     skip_whitespace
-    jal     get_hex_addr            
-    bnez    a2, cmd_C_error         # abort command if not found
-    mv		a4, a1
+	jal		skip_whitespace
+	jal		get_hex_addr			
+	bnez	a2, cmd_C_error			# abort command if not found
+	mv		a4, a1
 	# read dst_start from text buffer
-	jal     skip_whitespace
-    jal     get_hex_addr            
-    bnez    a2, cmd_C_error         # abort command if not found
-    mv      a5, a1
+	jal		skip_whitespace
+	jal		get_hex_addr			
+	bnez	a2, cmd_C_error			# abort command if not found
+	mv		a5, a1
 	
 	# a3: src_start
 	# a4: src_end
@@ -36,9 +36,9 @@ cmd_C_loop_forward:
 	lb		t0, 0(a3)
 	sb		t0, 0(a5)
 	addi	a3, a3, 1
-	addi 	a5, a5, 1
+	addi	a5, a5, 1
 	bgt		a3, a4, cmd_C_done
-    j       cmd_C_loop_forward
+	j		cmd_C_loop_forward
 
 cmd_C_do_backwards:
 	sub		t1, a4, a3
@@ -47,17 +47,17 @@ cmd_C_loop_backwards:
 	lb		t0, 0(a4)
 	sb		t0, 0(a5)
 	addi	a4, a4, -1
-	addi 	a5, a5, -1
-	blt 	a4, a3, cmd_C_done
-    j       cmd_C_loop_backwards
+	addi	a5, a5, -1
+	blt		a4, a3, cmd_C_done
+	j		cmd_C_loop_backwards
 
 cmd_C_error:
-    la      a0, error_param
-    jal     print_string
+	la		a0, error_param
+	jal		print_string
 
 cmd_C_done:
-    j       main_prompt
-.size cmd_C, .-cmd_C
+	j		main_prompt
+	.size cmd_C, .-cmd_C
 
 
-#endif /* WITH_CMD_C */
+	#endif /* WITH_CMD_C */

--- a/src/cmd_D.S
+++ b/src/cmd_D.S
@@ -1,98 +1,98 @@
-#include "vmon/config.h"
-#include "vmon/ASCII.h"
+	#include "vmon/config.h"
+	#include "vmon/ASCII.h"
 
 
-#ifdef WITH_CMD_D
+	#ifdef WITH_CMD_D
 
-.global cmd_D
+	.global cmd_D
 
-.text
+	.text
 
 
 cmd_D:
-    jal     skip_whitespace
-    jal     get_hex_addr            # read start addr from text buffer
-    bnez    a2, cmd_D_from_last     # none given? continue from last saved addr
-    mv      s5, a1                  # save start addr of dump
-    jal     skip_whitespace
-    jal     get_hex_addr            # read start addr from text buffer
-    mv      s7, a1                  # save end addr of dump
-    beqz    a2, cmd_D_next_instruction
-    j       cmd_D_add_default 
+	jal		skip_whitespace
+	jal		get_hex_addr			# read start addr from text buffer
+	bnez	a2, cmd_D_from_last		# none given? continue from last saved addr
+	mv		s5, a1					# save start addr of dump
+	jal		skip_whitespace
+	jal		get_hex_addr			# read start addr from text buffer
+	mv		s7, a1					# save end addr of dump
+	beqz	a2, cmd_D_next_instruction
+	j		cmd_D_add_default 
 cmd_D_from_last:
-    # continue from last address used
-    la      a1, last_address
-    LOAD_X  s5, 0(a1)
+	# continue from last address used
+	la		a1, last_address
+	LOAD_X	s5, 0(a1)
 cmd_D_add_default:
-    # no end addr? use default 
-    addi    s7, s5, DEFAULT_D_LINES*4-1          
-    # start addr now in s5, end addr now in s7
+	# no end addr? use default 
+	addi	s7, s5, DEFAULT_D_LINES*4-1			 
+	# start addr now in s5, end addr now in s7
 cmd_D_next_instruction:
-    # print memory address
-    mv      a0, s5                      # print current address
-    jal     print_hex
-    la      a0, string_asm_sep1
-    jal     print_string
-    # print word at this memory address
-    lw      a0, 0(s5)                   # load instruction word
-    mv      s6, a0                      # save for later
-    jal     insn_is_compressed
-    bnez    a0, cmd_D_word_is_RVC
+	# print memory address
+	mv		a0, s5						# print current address
+	jal		print_hex
+	la		a0, string_asm_sep1
+	jal		print_string
+	# print word at this memory address
+	lw		a0, 0(s5)					# load instruction word
+	mv		s6, a0						# save for later
+	jal		insn_is_compressed
+	bnez	a0, cmd_D_word_is_RVC
 cmd_D_word_not_RVC:
-    lbu     a0, 3(s5)                   # print 4 bytes if not compressed
-    jal     print_hex_byte
-    lbu     a0, 2(s5)
-    jal     print_hex_byte
-    lbu     a0, 1(s5)
-    jal     print_hex_byte
-    lbu     a0, 0(s5)
-    jal     print_hex_byte
-    j       cmd_D_disass    
-cmd_D_word_is_RVC:                   
-    lbu     a0, 1(s5)                   # print 2 bytes only
-    jal     print_hex_byte
-    lbu     a0, 0(s5)
-    jal     print_hex_byte
-    li      a0, ' '
-    jal     print_char                  # print 4 spaces for alignment
-    jal     print_char
-    jal     print_char
-    jal     print_char
+	lbu		a0, 3(s5)					# print 4 bytes if not compressed
+	jal		print_hex_byte
+	lbu		a0, 2(s5)
+	jal		print_hex_byte
+	lbu		a0, 1(s5)
+	jal		print_hex_byte
+	lbu		a0, 0(s5)
+	jal		print_hex_byte
+	j		cmd_D_disass	
+cmd_D_word_is_RVC:					 
+	lbu		a0, 1(s5)					# print 2 bytes only
+	jal		print_hex_byte
+	lbu		a0, 0(s5)
+	jal		print_hex_byte
+	li		a0, ' '
+	jal		print_char					# print 4 spaces for alignment
+	jal		print_char
+	jal		print_char
+	jal		print_char
 cmd_D_disass:
-    la      a0, string_asm_sep2     
-    jal     print_string
-    # disassemble this word
-    mv      a0, s6                      # get instruction word again
-    jal     decode_opcode
-    beqz    a1, cmd_D_opcode_unknown
-#ifdef ENABLE_RVC
-    jal     adjust_RVC_add_jal_ebreak
-#endif    
-    jal     print_instruction
-    j       cmd_D_advance
+	la		a0, string_asm_sep2		
+	jal		print_string
+	# disassemble this word
+	mv		a0, s6						# get instruction word again
+	jal		decode_opcode
+	beqz	a1, cmd_D_opcode_unknown
+	#ifdef ENABLE_RVC
+	jal		adjust_RVC_add_jal_ebreak
+	#endif	  
+	jal		print_instruction
+	j		cmd_D_advance
 cmd_D_opcode_unknown:
-    la      a0, string_OP_UNKNOWN
-    jal     print_string
-    j       cmd_D_advance
+	la		a0, string_OP_UNKNOWN
+	jal		print_string
+	j		cmd_D_advance
 cmd_D_advance:
-    mv      a0, s6                      # get instruction word again
-    addi    s5, s5, 2                   # advance 2 bytes in any case
-    jal     insn_is_compressed
-    bnez    a0, cmd_D_advance_done
-    addi    s5, s5, 2                   # add 2 more bytes if not compressed
+	mv		a0, s6						# get instruction word again
+	addi	s5, s5, 2					# advance 2 bytes in any case
+	jal		insn_is_compressed
+	bnez	a0, cmd_D_advance_done
+	addi	s5, s5, 2					# add 2 more bytes if not compressed
 cmd_D_advance_done:
-    bgt     s5, s7, cmd_D_done          # check if end address reached
-    jal     print_newline
-    j       cmd_D_next_instruction
+	bgt		s5, s7, cmd_D_done			# check if end address reached
+	jal		print_newline
+	j		cmd_D_next_instruction
 cmd_D_done:
-    la      a0, last_address 
-    SAVE_X  s5, 0(a0)
-    j       main_prompt
-.size cmd_D, .-cmd_D
- 
- 
-.data
-string_OP_UNKNOWN:      .string "???";
-.size string_OP_UNKNOWN, .-string_OP_UNKNOWN
+	la		a0, last_address 
+	SAVE_X	s5, 0(a0)
+	j		main_prompt
+	.size cmd_D, .-cmd_D
 	
-#endif /* WITH_CMD_D */
+	
+	.data
+string_OP_UNKNOWN:		.string "???";
+	.size string_OP_UNKNOWN, .-string_OP_UNKNOWN
+	
+	#endif /* WITH_CMD_D */

--- a/src/cmd_F.S
+++ b/src/cmd_F.S
@@ -1,29 +1,29 @@
-#include "vmon/config.h"
+	#include "vmon/config.h"
 
 
-#ifdef WITH_CMD_F
+	#ifdef WITH_CMD_F
 
-.global cmd_F
+	.global cmd_F
 
-.text
+	.text
 
 
 cmd_F:
 	# read src_start from text buffer	
-    jal     skip_whitespace
-    jal     get_hex_addr            # read start_addr from text buffer
-    bnez    a2, cmd_F_error         # abort command if not found
+	jal		skip_whitespace
+	jal		get_hex_addr			# read start_addr from text buffer
+	bnez	a2, cmd_F_error			# abort command if not found
 	mv		a3, a1
 	# read src_end from text buffer
-	jal     skip_whitespace
-    jal     get_hex_addr            # read end_addr from text buffer
-    bnez    a2, cmd_F_error         # abort command if not found
-    mv		a4, a1
+	jal		skip_whitespace
+	jal		get_hex_addr			# read end_addr from text buffer
+	bnez	a2, cmd_F_error			# abort command if not found
+	mv		a4, a1
 	# read byte_value from text buffer
-	jal     skip_whitespace
-    jal     get_hex_addr            
-    bnez    a2, cmd_F_error         # abort command if not found
-    mv      a5, a1
+	jal		skip_whitespace
+	jal		get_hex_addr			
+	bnez	a2, cmd_F_error			# abort command if not found
+	mv		a5, a1
 	
 	# a3: src_start
 	# a4: src_end
@@ -33,18 +33,18 @@ cmd_F_loop_forward:
 	beq		t0, a5, cmd_F_found
 	addi	a3, a3, 1
 	bgt		a3, a4, cmd_F_done
-    j       cmd_F_loop_forward
+	j		cmd_F_loop_forward
 
 cmd_F_found:
 	mv		a0, a3
 	jal		print_hex
-	j 		cmd_F_done
+	j		cmd_F_done
 cmd_F_error:
-    la      a0, error_param
-    jal     print_string
+	la		a0, error_param
+	jal		print_string
 cmd_F_done:
-    j       main_prompt
-.size cmd_F, .-cmd_F
+	j		main_prompt
+	.size cmd_F, .-cmd_F
 
 
-#endif /* WITH_CMD_F */
+	#endif /* WITH_CMD_F */

--- a/src/cmd_G.S
+++ b/src/cmd_G.S
@@ -1,34 +1,34 @@
-#include "vmon/config.h"
+	#include "vmon/config.h"
 
 
-#ifdef WITH_CMD_G
+	#ifdef WITH_CMD_G
 
-.global cmd_G
+	.global cmd_G
 
-.text
+	.text
 
 
 cmd_G:
-    jal     skip_whitespace
-    jal     get_hex_addr            # read start addr from text buffer
-    bnez    a2, cmd_G_error         # abort command if not found
-    mv      s1, a1
-    la      a0, string_go
-    jal     print_string
-    mv      a0, s1
-    jal     print_hex
-    # TODO: what about stack?
-    jalr    ra, s1, 0
-    j       start                   # start over if the call returns
+	jal		skip_whitespace
+	jal		get_hex_addr			# read start addr from text buffer
+	bnez	a2, cmd_G_error			# abort command if not found
+	mv		s1, a1
+	la		a0, string_go
+	jal		print_string
+	mv		a0, s1
+	jal		print_hex
+	# TODO: what about stack?
+	jalr	ra, s1, 0
+	j		start					# start over if the call returns
 cmd_G_error:
-    la      a0, error_param
-    jal     print_string
-    j       main_prompt
-.size cmd_G, .-cmd_G
+	la		a0, error_param
+	jal		print_string
+	j		main_prompt
+	.size cmd_G, .-cmd_G
 
 
-.data
-string_go:              .string "jumping to ";
-.size string_go, .-string_go
+	.data
+string_go:				.string "jumping to ";
+	.size string_go, .-string_go
 
-#endif /* WITH_CMD_G */
+	#endif /* WITH_CMD_G */

--- a/src/cmd_H.S
+++ b/src/cmd_H.S
@@ -1,37 +1,37 @@
-#include "vmon/config.h"
+	#include "vmon/config.h"
 
 
-#ifdef WITH_CMD_H
+	#ifdef WITH_CMD_H
 
-.global cmd_H
+	.global cmd_H
 
-.text
+	.text
 
 
 cmd_H:
-    la      a0, string_help
-    jal     print_string
-    j       main_prompt
-.size cmd_H, .-cmd_H
+	la		a0, string_help
+	jal		print_string
+	j		main_prompt
+	.size cmd_H, .-cmd_H
 
 
-.data
+	.data
 string_help:
-.string "\nCommands:\n\
-    a <start_addr> - assembly input (ENTER to stop)\n\
-    c <src_start> <src_end> <dst_start> - copy memory\n\
-    d <start_addr> - disassemble 16 instructions starting at start_addr\n\
-    d <start_addr> <end_addr> - disassemble from start_addr to end_addr\n\
-    d - continue disassembly from last address\n\
-    f <start_addr> <end_addr> <byte_value> - find byte value\n\
-    g <start_addr> - go to start_addr\n\
-    h - help\n\
-    i - print segment and debugging information\n\
-    m <start_addr> - memory dump 128 bytes starting at start_addr\n\
-    m <start_addr> <end_addr> - memory dump from start_addr to end_addr\n\
-    m - continue memory dump from last address\n\
-    p <dst_addr> <byte_value0> [...] - write byte_value(s) starting at dst_addr\n\
-    x - exit to caller\n\
-    All address and value entries are in hex (without 0x prefix).\n"
-.size string_help, .-string_help
-#endif /* WITH_CMD_H */
+	.string "\nCommands:\n\
+	a <start_addr> - assembly input (ENTER to stop)\n\
+	c <src_start> <src_end> <dst_start> - copy memory\n\
+	d <start_addr> - disassemble 16 instructions starting at start_addr\n\
+	d <start_addr> <end_addr> - disassemble from start_addr to end_addr\n\
+	d - continue disassembly from last address\n\
+	f <start_addr> <end_addr> <byte_value> - find byte value\n\
+	g <start_addr> - go to start_addr\n\
+	h - help\n\
+	i - print segment and debugging information\n\
+	m <start_addr> - memory dump 128 bytes starting at start_addr\n\
+	m <start_addr> <end_addr> - memory dump from start_addr to end_addr\n\
+	m - continue memory dump from last address\n\
+	p <dst_addr> <byte_value0> [...] - write byte_value(s) starting at dst_addr\n\
+	x - exit to caller\n\
+	All address and value entries are in hex (without 0x prefix).\n"
+	.size string_help, .-string_help
+	#endif /* WITH_CMD_H */

--- a/src/cmd_I.S
+++ b/src/cmd_I.S
@@ -1,304 +1,304 @@
-#include "vmon/config.h"
+	#include "vmon/config.h"
 
 
-#ifdef WITH_CMD_I
+	#ifdef WITH_CMD_I
 
-.global cmd_I
+	.global cmd_I
 
-.text
+	.text
 
 
 cmd_I:
-    la      a0, string_info_instructionset
-    jal     print_string
-    li      a0, XLEN
-    jal     print_decimal
-    li      a0, 'i'
-    jal     print_char
-#ifdef ENABLE_RVM
-    li      a0, 'm'
-    jal     print_char
-#endif
-#ifdef ENABLE_RVA
-    li      a0, 'a'
-    jal     print_char
-#endif
-#ifdef ENABLE_RVF
-    li      a0, 'f'
-    jal     print_char
-#endif
-#ifdef ENABLE_RVD
-    li      a0, 'd'
-    jal     print_char
-#endif
-#ifdef ENABLE_RVQ
-    li      a0, 'q'
-    jal     print_char
-#endif
-#ifdef ENABLE_RVC
-    li      a0, 'c'
-    jal     print_char
-#endif
-#ifdef ENABLE_RVV
-    li      a0, 'v'
-    jal     print_char
-#endif
-#ifdef ENABLE_RVZicsr
-    la      a0, string_info_Zicsr 
-    jal     print_string
-#endif
-#ifdef ENABLE_RVZifencei
-    la      a0, string_info_Zifencei
-    jal     print_string
-#endif
+	la		a0, string_info_instructionset
+	jal		print_string
+	li		a0, XLEN
+	jal		print_decimal
+	li		a0, 'i'
+	jal		print_char
+	#ifdef ENABLE_RVM
+	li		a0, 'm'
+	jal		print_char
+	#endif
+	#ifdef ENABLE_RVA
+	li		a0, 'a'
+	jal		print_char
+	#endif
+	#ifdef ENABLE_RVF
+	li		a0, 'f'
+	jal		print_char
+	#endif
+	#ifdef ENABLE_RVD
+	li		a0, 'd'
+	jal		print_char
+	#endif
+	#ifdef ENABLE_RVQ
+	li		a0, 'q'
+	jal		print_char
+	#endif
+	#ifdef ENABLE_RVC
+	li		a0, 'c'
+	jal		print_char
+	#endif
+	#ifdef ENABLE_RVV
+	li		a0, 'v'
+	jal		print_char
+	#endif
+	#ifdef ENABLE_RVZicsr
+	la		a0, string_info_Zicsr 
+	jal		print_string
+	#endif
+	#ifdef ENABLE_RVZifencei
+	la		a0, string_info_Zifencei
+	jal		print_string
+	#endif
 
-    la      a0, string_info_text
-    jal     print_string
-    la      a0, start    
-    jal     print_hex
+	la		a0, string_info_text
+	jal		print_string
+	la		a0, start	 
+	jal		print_hex
 
-    la      a0, string_info_data
-    jal     print_string
-    la      a0, start_data    
-    jal     print_hex
+	la		a0, string_info_data
+	jal		print_string
+	la		a0, start_data	  
+	jal		print_hex
 
-    la      a0, string_info_bss
-    jal     print_string
-    la      a0, start_bss    
-    jal     print_hex
+	la		a0, string_info_bss
+	jal		print_string
+	la		a0, start_bss	 
+	jal		print_hex
 
-#ifdef BARE_METAL
-    la      a0, string_info_stackstart
-    jal     print_string
-    la      a0, stack   
-    jal     print_hex
+	#ifdef BARE_METAL
+	la		a0, string_info_stackstart
+	jal		print_string
+	la		a0, stack	
+	jal		print_hex
 
-    la      a0, string_info_stackend
-    jal     print_string
-    la      a0, stack + STACK_SIZE   
-    jal     print_hex
+	la		a0, string_info_stackend
+	jal		print_string
+	la		a0, stack + STACK_SIZE	 
+	jal		print_hex
 
-    la      a0, string_info_stacksize
-    jal     print_string
-    la      t0, stack    
-    sub     a0, sp, t0
-    jal     print_hex
-#endif /* BARE_METAL */
+	la		a0, string_info_stacksize
+	jal		print_string
+	la		t0, stack	 
+	sub		a0, sp, t0
+	jal		print_hex
+	#endif /* BARE_METAL */
 
-#ifdef WITH_TESTCODE
-    la      a0, string_info_testcode
-    jal     print_string
-    la      a0, testcode 
-    jal     print_hex
+	#ifdef WITH_TESTCODE
+	la		a0, string_info_testcode
+	jal		print_string
+	la		a0, testcode 
+	jal		print_hex
 
-    #ifdef WITH_TESTCODE_RV32I
-        la      a0, string_info_testcode_RV32I
-        jal     print_string
-        la      a0, testcode_RV32I
-        jal     print_hex
-    #endif /* WITH_TESTCODE_RV32I */
+	#ifdef WITH_TESTCODE_RV32I
+	la		a0, string_info_testcode_RV32I
+	jal		print_string
+	la		a0, testcode_RV32I
+	jal		print_hex
+	#endif /* WITH_TESTCODE_RV32I */
 
-    #if defined(WITH_TESTCODE_RV64I) && (XLEN >= 64)
-        la      a0, string_info_testcode_RV64I
-        jal     print_string
-        la      a0, testcode_RV64I
-        jal     print_hex
-    #endif /* WITH_TESTCODE_RV64I */
+	#if defined(WITH_TESTCODE_RV64I) && (XLEN >= 64)
+	la		a0, string_info_testcode_RV64I
+	jal		print_string
+	la		a0, testcode_RV64I
+	jal		print_hex
+	#endif /* WITH_TESTCODE_RV64I */
 
-    #ifdef WITH_TESTCODE_RVM
-        la      a0, string_info_testcode_RVM
-        jal     print_string
-        la      a0, testcode_RVM
-        jal     print_hex
-    #endif /* WITH_TESTCODE_RVM */
+	#ifdef WITH_TESTCODE_RVM
+	la		a0, string_info_testcode_RVM
+	jal		print_string
+	la		a0, testcode_RVM
+	jal		print_hex
+	#endif /* WITH_TESTCODE_RVM */
 
-    #ifdef WITH_TESTCODE_RVA
-        la      a0, string_info_testcode_RVA
-        jal     print_string
-        la      a0, testcode_RVA
-        jal     print_hex
-    #endif /* WITH_TESTCODE_RVA */
+	#ifdef WITH_TESTCODE_RVA
+	la		a0, string_info_testcode_RVA
+	jal		print_string
+	la		a0, testcode_RVA
+	jal		print_hex
+	#endif /* WITH_TESTCODE_RVA */
 
-    #ifdef WITH_TESTCODE_RVF
-        la      a0, string_info_testcode_RVF
-        jal     print_string
-        la      a0, testcode_RVF
-        jal     print_hex
-    #endif /* WITH_TESTCODE_RVF */
+	#ifdef WITH_TESTCODE_RVF
+	la		a0, string_info_testcode_RVF
+	jal		print_string
+	la		a0, testcode_RVF
+	jal		print_hex
+	#endif /* WITH_TESTCODE_RVF */
 
-    #if defined (WITH_TESTCODE_RVD) && XLEN >= 64
-        la      a0, string_info_testcode_RVD
-        jal     print_string
-        la      a0, testcode_RVD
-        jal     print_hex
-    #endif /* WITH_TESTCODE_RVD */
+	#if defined (WITH_TESTCODE_RVD) && XLEN >= 64
+	la		a0, string_info_testcode_RVD
+	jal		print_string
+	la		a0, testcode_RVD
+	jal		print_hex
+	#endif /* WITH_TESTCODE_RVD */
 
-    #if defined (WITH_TESTCODE_RVQ) && XLEN >= 128
-        la      a0, string_info_testcode_RVQ
-        jal     print_string
-        la      a0, testcode_RVQ
-        jal     print_hex
-    #endif /* WITH_TESTCODE_RVQ */
+	#if defined (WITH_TESTCODE_RVQ) && XLEN >= 128
+	la		a0, string_info_testcode_RVQ
+	jal		print_string
+	la		a0, testcode_RVQ
+	jal		print_hex
+	#endif /* WITH_TESTCODE_RVQ */
 
-    #if defined (WITH_TESTCODE_RVC) && defined (ENABLE_RVC)
-        la      a0, string_info_testcode_RVC
-        jal     print_string
-        la      a0, testcode_RVC
-        jal     print_hex
-    #endif /* WITH_TESTCODE_RVC */
+	#if defined (WITH_TESTCODE_RVC) && defined (ENABLE_RVC)
+	la		a0, string_info_testcode_RVC
+	jal		print_string
+	la		a0, testcode_RVC
+	jal		print_hex
+	#endif /* WITH_TESTCODE_RVC */
 
-    #ifdef WITH_TESTCODE_RVV
-        la      a0, string_info_testcode_RVV
-        jal     print_string
-        la      a0, testcode_RVV
-        jal     print_hex
-    #endif /* WITH_TESTCODE_RVV */
+	#ifdef WITH_TESTCODE_RVV
+	la		a0, string_info_testcode_RVV
+	jal		print_string
+	la		a0, testcode_RVV
+	jal		print_hex
+	#endif /* WITH_TESTCODE_RVV */
 
-    #ifdef WITH_TESTCODE_RVZicsr
-        la      a0, string_info_testcode_RVZicsr
-        jal     print_string
-        la      a0, testcode_RVZicsr
-        jal     print_hex
-    #endif /* WITH_TESTCODE_RVZicsr */
+	#ifdef WITH_TESTCODE_RVZicsr
+	la		a0, string_info_testcode_RVZicsr
+	jal		print_string
+	la		a0, testcode_RVZicsr
+	jal		print_hex
+	#endif /* WITH_TESTCODE_RVZicsr */
 
-    #ifdef WITH_TESTCODE_RVZifencei
-        la      a0, string_info_testcode_RVZifencei
-        jal     print_string
-        la      a0, testcode_RVZifencei
-        jal     print_hex
-    #endif /* WITH_TESTCODE_RVZifencei */
+	#ifdef WITH_TESTCODE_RVZifencei
+	la		a0, string_info_testcode_RVZifencei
+	jal		print_string
+	la		a0, testcode_RVZifencei
+	jal		print_hex
+	#endif /* WITH_TESTCODE_RVZifencei */
 
-    #ifdef WITH_TESTCODE_RVPRIV
-        la      a0, string_info_testcode_RVPRIV
-        jal     print_string
-        la      a0, testcode_RVPRIV
-        jal     print_hex
-    #endif /* WITH_TESTCODE_RVPRIV */
+	#ifdef WITH_TESTCODE_RVPRIV
+	la		a0, string_info_testcode_RVPRIV
+	jal		print_string
+	la		a0, testcode_RVPRIV
+	jal		print_hex
+	#endif /* WITH_TESTCODE_RVPRIV */
 
-    #ifdef WITH_TESTCODE_PSEUDO
-        la      a0, string_info_testcode_PSEUDO
-        jal     print_string
-        la      a0, testcode_PSEUDO
-        jal     print_hex
-    #endif /* WITH_TESTCODE_PSEUDO */
+	#ifdef WITH_TESTCODE_PSEUDO
+	la		a0, string_info_testcode_PSEUDO
+	jal		print_string
+	la		a0, testcode_PSEUDO
+	jal		print_hex
+	#endif /* WITH_TESTCODE_PSEUDO */
 
-#endif /* WITH_TESTCODE */
+	#endif /* WITH_TESTCODE */
 
-    j       main_prompt
-.size cmd_I, .-cmd_I
+	j		main_prompt
+	.size cmd_I, .-cmd_I
 
 
-.data
+	.data
 string_info_instructionset:
-    .string "instructions: rv";
+	.string "instructions: rv";
 string_info_Zicsr:
-    .string "_Zicsr";
+	.string "_Zicsr";
 string_info_Zifencei:
-    .string "_Zifencei";
+	.string "_Zifencei";
 string_info_text:
-    .string "\n.text:  ";
-.size string_info_text, .-string_info_text
+	.string "\n.text:  ";
+	.size string_info_text, .-string_info_text
 string_info_data:
-    .string "\n.data:  ";
-.size string_info_data, .-string_info_data
+	.string "\n.data:  ";
+	.size string_info_data, .-string_info_data
 string_info_bss:
-    .string "\n.bss:   ";
-.size string_info_bss, .-string_info_bss
+	.string "\n.bss:   ";
+	.size string_info_bss, .-string_info_bss
 string_info_buffer:
-    .string "\nbuffer: ";
-.size string_info_buffer, .-string_info_buffer
+	.string "\nbuffer: ";
+	.size string_info_buffer, .-string_info_buffer
 string_info_stackstart:
-    .string "\nstack start: ";
-.size string_info_stackstart, .-string_info_stackstart
+	.string "\nstack start: ";
+	.size string_info_stackstart, .-string_info_stackstart
 string_info_stackend:
-    .string "\nstack end:   ";
-.size string_info_stackend, .-string_info_stackend
+	.string "\nstack end:	";
+	.size string_info_stackend, .-string_info_stackend
 string_info_stacksize:
-    .string "\nstack bytes free: ";
-.size string_info_stacksize, .-string_info_stacksize
+	.string "\nstack bytes free: ";
+	.size string_info_stacksize, .-string_info_stacksize
 
-#ifdef WITH_TESTCODE
-    string_info_testcode:
-        .string "\ntestcode: ";
-    .size string_info_testcode, .-string_info_testcode
+	#ifdef WITH_TESTCODE
+string_info_testcode:
+	.string "\ntestcode: ";
+	.size string_info_testcode, .-string_info_testcode
 
-    #ifdef WITH_TESTCODE_RV32I
-    string_info_testcode_RV32I:
-        .string "\n RV32I: ";
-    .size string_info_testcode_RV32I, .-string_info_testcode_RV32I
-    #endif
+	#ifdef WITH_TESTCODE_RV32I
+string_info_testcode_RV32I:
+	.string "\n RV32I: ";
+	.size string_info_testcode_RV32I, .-string_info_testcode_RV32I
+	#endif
 
-    #ifdef WITH_TESTCODE_RV64I
-    string_info_testcode_RV64I:
-        .string "\n RV64I: ";
-    .size string_info_testcode_RV64I, .-string_info_testcode_RV64I
-    #endif
+	#ifdef WITH_TESTCODE_RV64I
+string_info_testcode_RV64I:
+	.string "\n RV64I: ";
+	.size string_info_testcode_RV64I, .-string_info_testcode_RV64I
+	#endif
 
-    #ifdef WITH_TESTCODE_RVM
-    string_info_testcode_RVM:
-        .string "\n RVM: ";
-    .size string_info_testcode_RVM, .-string_info_testcode_RVM
-    #endif
+	#ifdef WITH_TESTCODE_RVM
+string_info_testcode_RVM:
+	.string "\n RVM: ";
+	.size string_info_testcode_RVM, .-string_info_testcode_RVM
+	#endif
 
-    #ifdef WITH_TESTCODE_RVA
-    string_info_testcode_RVA:
-        .string "\n RVA: ";
-    .size string_info_testcode_RAM, .-string_info_testcode_RVA
-    #endif
+	#ifdef WITH_TESTCODE_RVA
+string_info_testcode_RVA:
+	.string "\n RVA: ";
+	.size string_info_testcode_RAM, .-string_info_testcode_RVA
+	#endif
 
-    #ifdef WITH_TESTCODE_RVF
-    string_info_testcode_RVF:
-        .string "\n RVF: ";
-    .size string_info_testcode_RVF, .-string_info_testcode_RVF
-    #endif
+	#ifdef WITH_TESTCODE_RVF
+string_info_testcode_RVF:
+	.string "\n RVF: ";
+	.size string_info_testcode_RVF, .-string_info_testcode_RVF
+	#endif
 
-    #ifdef WITH_TESTCODE_RVD
-    string_info_testcode_RVD:
-        .string "\n RVD: ";
-    .size string_info_testcode_RVD, .-string_info_testcode_RVD
-    #endif
+	#ifdef WITH_TESTCODE_RVD
+string_info_testcode_RVD:
+	.string "\n RVD: ";
+	.size string_info_testcode_RVD, .-string_info_testcode_RVD
+	#endif
 
-    #ifdef WITH_TESTCODE_RVQ
-    string_info_testcode_RVQ:
-        .string "\n RVQ: ";
-    .size string_info_testcode_RVQ, .-string_info_testcode_RVQ
-    #endif
+	#ifdef WITH_TESTCODE_RVQ
+string_info_testcode_RVQ:
+	.string "\n RVQ: ";
+	.size string_info_testcode_RVQ, .-string_info_testcode_RVQ
+	#endif
 
-    #ifdef WITH_TESTCODE_RVC
-    string_info_testcode_RVC:
-        .string "\n RVC: ";
-    .size string_info_testcode_RVC, .-string_info_testcode_RVC
-    #endif
+	#ifdef WITH_TESTCODE_RVC
+string_info_testcode_RVC:
+	.string "\n RVC: ";
+	.size string_info_testcode_RVC, .-string_info_testcode_RVC
+	#endif
 
-    #ifdef WITH_TESTCODE_RVV
-    string_info_testcode_RVV:
-        .string "\n RVV: ";
-    .size string_info_testcode_RVV, .-string_info_testcode_RVV
-    #endif
+	#ifdef WITH_TESTCODE_RVV
+string_info_testcode_RVV:
+	.string "\n RVV: ";
+	.size string_info_testcode_RVV, .-string_info_testcode_RVV
+	#endif
 
-    #ifdef WITH_TESTCODE_RVZicsr
-    string_info_testcode_RVZicsr:
-        .string "\n RVZicsr: ";
-    .size string_info_testcode_RVZicsr, .-string_info_testcode_RVZicsr
-    #endif
+	#ifdef WITH_TESTCODE_RVZicsr
+string_info_testcode_RVZicsr:
+	.string "\n RVZicsr: ";
+	.size string_info_testcode_RVZicsr, .-string_info_testcode_RVZicsr
+	#endif
 
-    #ifdef WITH_TESTCODE_RVZifencei
-    string_info_testcode_RVZifencei:
-        .string "\n RVZifencei: ";
-    .size string_info_testcode_RVZifencei, .-string_info_testcode_RVZifencei
-    #endif
+	#ifdef WITH_TESTCODE_RVZifencei
+string_info_testcode_RVZifencei:
+	.string "\n RVZifencei: ";
+	.size string_info_testcode_RVZifencei, .-string_info_testcode_RVZifencei
+	#endif
 
-    #ifdef WITH_TESTCODE_RVPRIV
-    string_info_testcode_RVPRIV:
-        .string "\n RVPRIV: ";
-    .size string_info_testcode_RVPRIV, .-string_info_testcode_RVPRIV
-    #endif
+	#ifdef WITH_TESTCODE_RVPRIV
+string_info_testcode_RVPRIV:
+	.string "\n RVPRIV: ";
+	.size string_info_testcode_RVPRIV, .-string_info_testcode_RVPRIV
+	#endif
 
-    #ifdef WITH_TESTCODE_PSEUDO
-    string_info_testcode_PSEUDO:
-        .string "\n PSEUDO: ";
-    .size string_info_testcode_PSEUDO, .-string_info_testcode_PSEUDO
-    #endif
-#endif /* WITH_TESTCODE */
+	#ifdef WITH_TESTCODE_PSEUDO
+string_info_testcode_PSEUDO:
+	.string "\n PSEUDO: ";
+	.size string_info_testcode_PSEUDO, .-string_info_testcode_PSEUDO
+	#endif
+	#endif /* WITH_TESTCODE */
 
-#endif /* WITH_CMD_I */
+	#endif /* WITH_CMD_I */

--- a/src/cmd_M.S
+++ b/src/cmd_M.S
@@ -1,66 +1,66 @@
-#include "vmon/config.h"
-#include "vmon/ASCII.h"
+	#include "vmon/config.h"
+	#include "vmon/ASCII.h"
 
 
-#ifdef WITH_CMD_M
+	#ifdef WITH_CMD_M
 
-.global cmd_M
+	.global cmd_M
 
-.text
+	.text
 
 
 cmd_M:
-    jal     skip_whitespace
-    jal     get_hex_addr            # read start addr from text buffer
-    bnez    a2, cmd_M_from_last     # none given? continue from last saved addr
-    mv      s5, a1                  # save start addr of dump
-    jal     skip_whitespace
-    jal     get_hex_addr            # read end addr from text buffer
-    mv      s7, a1                  # save end addr of dump
-    beqz    a2, cmd_M_next_line
-    j       cmd_M_add_default 
+	jal		skip_whitespace
+	jal		get_hex_addr			# read start addr from text buffer
+	bnez	a2, cmd_M_from_last		# none given? continue from last saved addr
+	mv		s5, a1					# save start addr of dump
+	jal		skip_whitespace
+	jal		get_hex_addr			# read end addr from text buffer
+	mv		s7, a1					# save end addr of dump
+	beqz	a2, cmd_M_next_line
+	j		cmd_M_add_default 
 cmd_M_from_last:
-    # continue from last address used
-    la      a1, last_address
-    LOAD_X  s5, 0(a1)
+	# continue from last address used
+	la		a1, last_address
+	LOAD_X	s5, 0(a1)
 cmd_M_add_default:
-    # no end addr? use default
-    addi    s7, s5, DEFAULT_M_LINES*8-1  
-    # start addr now in s5, end addr now in s7
+	# no end addr? use default
+	addi	s7, s5, DEFAULT_M_LINES*8-1	 
+	# start addr now in s5, end addr now in s7
 cmd_M_next_line:
-    mv      a0, s5
-    jal     print_hex
-    li      a0, ':'
-    jal     print_char
-    # output hex bytes 
-    addi    s6, s5, 8               # set end addr for output line
- cmd_M_next_byte:
-    beq     s5, s6, cmd_M_print_ascii  
-    li      a0, ' '
-    jal     print_char
-    lbu     a0, 0(s5)               # get byte from memory address
-    jal     print_hex_byte
-    addi    s5, s5, 1
-    j       cmd_M_next_byte
-    # output the same hex bytes again, this time as ASCII chars
+	mv		a0, s5
+	jal		print_hex
+	li		a0, ':'
+	jal		print_char
+	# output hex bytes 
+	addi	s6, s5, 8				# set end addr for output line
+cmd_M_next_byte:
+	beq		s5, s6, cmd_M_print_ascii  
+	li		a0, ' '
+	jal		print_char
+	lbu		a0, 0(s5)				# get byte from memory address
+	jal		print_hex_byte
+	addi	s5, s5, 1
+	j		cmd_M_next_byte
+	# output the same hex bytes again, this time as ASCII chars
 cmd_M_print_ascii:
-    addi    s5, s5, -8
-    li      a0, ' '
-    jal     print_char
+	addi	s5, s5, -8
+	li		a0, ' '
+	jal		print_char
 cmd_M_next_char:
-    beq     s5, s6, cmd_M_ascii_done
-    lbu     a0, 0(s5)              # get byte from memory address
-    jal     print_ascii
-    addi    s5, s5, 1
-    j       cmd_M_next_char
+	beq		s5, s6, cmd_M_ascii_done
+	lbu		a0, 0(s5)			   # get byte from memory address
+	jal		print_ascii
+	addi	s5, s5, 1
+	j		cmd_M_next_char
 cmd_M_ascii_done:
-    bgt     s5, s7, cmd_M_done
-    jal     print_newline
-    j       cmd_M_next_line
+	bgt		s5, s7, cmd_M_done
+	jal		print_newline
+	j		cmd_M_next_line
 cmd_M_done:
-    la      a0, last_address 
-    SAVE_X  s5, 0(a0)
-    j       main_prompt
-.size cmd_M, .-cmd_M
+	la		a0, last_address 
+	SAVE_X	s5, 0(a0)
+	j		main_prompt
+	.size cmd_M, .-cmd_M
 
-#endif /* WITH_CMD_M */
+	#endif /* WITH_CMD_M */

--- a/src/cmd_P.S
+++ b/src/cmd_P.S
@@ -1,41 +1,41 @@
-#include "vmon/config.h"
+	#include "vmon/config.h"
 
 
-#ifdef WITH_CMD_P
+	#ifdef WITH_CMD_P
 
-.global cmd_P
+	.global cmd_P
 
-.text
+	.text
 
 
 cmd_P:
 	# read dst_addr from text buffer	
-    jal     skip_whitespace
-    jal     get_hex_addr            # read src_start from text buffer
-    bnez    a2, cmd_P_error         # abort command if not found
+	jal		skip_whitespace
+	jal		get_hex_addr			# read src_start from text buffer
+	bnez	a2, cmd_P_error			# abort command if not found
 	mv		a3, a1
 	
-    # read byte_value from text buffer
+	# read byte_value from text buffer
 cmd_P_next_byte_value:
-	jal     skip_whitespace
-    jal     get_hex_addr            
-    bnez    a2, cmd_P_done         # end if no more valid input
-    mv		a4, a1
+	jal		skip_whitespace
+	jal		get_hex_addr			
+	bnez	a2, cmd_P_done		   # end if no more valid input
+	mv		a4, a1
 	
 	# a3: dst_addr
 	# a4: byte_value
 	sb		a4, 0(a3)				# writes only lower 8 bits
 	
-    addi    a3, a3, 1               # increase target addr by 1 byte
-    j       cmd_P_next_byte_value   # repeat until end of input buffer
+	addi	a3, a3, 1				# increase target addr by 1 byte
+	j		cmd_P_next_byte_value	# repeat until end of input buffer
 
 cmd_P_error:
-    la      a0, error_param
-    jal     print_string
+	la		a0, error_param
+	jal		print_string
 
 cmd_P_done:
-    j       main_prompt
-.size cmd_P, .-cmd_P
+	j		main_prompt
+	.size cmd_P, .-cmd_P
 
 
-#endif /* WITH_CMD_P */
+	#endif /* WITH_CMD_P */

--- a/src/cmd_X.S
+++ b/src/cmd_X.S
@@ -1,58 +1,58 @@
-#include "vmon/config.h"
+	#include "vmon/config.h"
 
 
-#ifdef WITH_CMD_X
+	#ifdef WITH_CMD_X
 
-.global cmd_X
+	.global cmd_X
 
-.text
+	.text
 
 
 cmd_X:
-    la      a0, string_exit
-    jal     print_string
-    LOAD_X  a0, 0(sp)      
-    jal     print_hex
-    # restore registers
-    LOAD_X  ra, 0(sp)      
-    LOAD_X  x3, (XLEN_BYTES*2)(sp)      
-    LOAD_X  x4, (XLEN_BYTES*3)(sp)      
-    LOAD_X  x5, (XLEN_BYTES*4)(sp)      
-    LOAD_X  x6, (XLEN_BYTES*5)(sp)      
-    LOAD_X  x7, (XLEN_BYTES*6)(sp)      
-    LOAD_X  x8, (XLEN_BYTES*7)(sp)      
-    LOAD_X  x9, (XLEN_BYTES*8)(sp)      
-    LOAD_X  x10, (XLEN_BYTES*9)(sp)      
-    LOAD_X  x11, (XLEN_BYTES*10)(sp)      
-    LOAD_X  x12, (XLEN_BYTES*11)(sp)      
-    LOAD_X  x13, (XLEN_BYTES*12)(sp)      
-    LOAD_X  x14, (XLEN_BYTES*13)(sp)      
-    LOAD_X  x15, (XLEN_BYTES*14)(sp)      
-    LOAD_X  x16, (XLEN_BYTES*15)(sp)      
-    LOAD_X  x17, (XLEN_BYTES*16)(sp)      
-    LOAD_X  x18, (XLEN_BYTES*17)(sp)      
-    LOAD_X  x19, (XLEN_BYTES*18)(sp)      
-    LOAD_X  x20, (XLEN_BYTES*19)(sp)      
-    LOAD_X  x21, (XLEN_BYTES*20)(sp)      
-    LOAD_X  x22, (XLEN_BYTES*21)(sp)      
-    LOAD_X  x23, (XLEN_BYTES*22)(sp)      
-    LOAD_X  x24, (XLEN_BYTES*23)(sp)      
-    LOAD_X  x25, (XLEN_BYTES*24)(sp)      
-    LOAD_X  x26, (XLEN_BYTES*25)(sp)      
-    LOAD_X  x27, (XLEN_BYTES*26)(sp)      
-    LOAD_X  x28, (XLEN_BYTES*27)(sp)      
-    LOAD_X  x29, (XLEN_BYTES*28)(sp)      
-    LOAD_X  x30, (XLEN_BYTES*29)(sp)      
-    LOAD_X  x31, (XLEN_BYTES*30)(sp)      
-    # the original sp from caller
-    LOAD_X  sp, (XLEN_BYTES*1)(sp)     
-    # return control to caller     
-    jalr    zero, ra, 0     
-.size cmd_X, .-cmd_X
+	la		a0, string_exit
+	jal		print_string
+	LOAD_X	a0, 0(sp)	   
+	jal		print_hex
+	# restore registers
+	LOAD_X	ra, 0(sp)	   
+	LOAD_X	x3, (XLEN_BYTES*2)(sp)		
+	LOAD_X	x4, (XLEN_BYTES*3)(sp)		
+	LOAD_X	x5, (XLEN_BYTES*4)(sp)		
+	LOAD_X	x6, (XLEN_BYTES*5)(sp)		
+	LOAD_X	x7, (XLEN_BYTES*6)(sp)		
+	LOAD_X	x8, (XLEN_BYTES*7)(sp)		
+	LOAD_X	x9, (XLEN_BYTES*8)(sp)		
+	LOAD_X	x10, (XLEN_BYTES*9)(sp)		 
+	LOAD_X	x11, (XLEN_BYTES*10)(sp)	  
+	LOAD_X	x12, (XLEN_BYTES*11)(sp)	  
+	LOAD_X	x13, (XLEN_BYTES*12)(sp)	  
+	LOAD_X	x14, (XLEN_BYTES*13)(sp)	  
+	LOAD_X	x15, (XLEN_BYTES*14)(sp)	  
+	LOAD_X	x16, (XLEN_BYTES*15)(sp)	  
+	LOAD_X	x17, (XLEN_BYTES*16)(sp)	  
+	LOAD_X	x18, (XLEN_BYTES*17)(sp)	  
+	LOAD_X	x19, (XLEN_BYTES*18)(sp)	  
+	LOAD_X	x20, (XLEN_BYTES*19)(sp)	  
+	LOAD_X	x21, (XLEN_BYTES*20)(sp)	  
+	LOAD_X	x22, (XLEN_BYTES*21)(sp)	  
+	LOAD_X	x23, (XLEN_BYTES*22)(sp)	  
+	LOAD_X	x24, (XLEN_BYTES*23)(sp)	  
+	LOAD_X	x25, (XLEN_BYTES*24)(sp)	  
+	LOAD_X	x26, (XLEN_BYTES*25)(sp)	  
+	LOAD_X	x27, (XLEN_BYTES*26)(sp)	  
+	LOAD_X	x28, (XLEN_BYTES*27)(sp)	  
+	LOAD_X	x29, (XLEN_BYTES*28)(sp)	  
+	LOAD_X	x30, (XLEN_BYTES*29)(sp)	  
+	LOAD_X	x31, (XLEN_BYTES*30)(sp)	  
+	# the original sp from caller
+	LOAD_X	sp, (XLEN_BYTES*1)(sp)	   
+	# return control to caller	   
+	jalr	zero, ra, 0		
+	.size cmd_X, .-cmd_X
 
 
-.data
-string_exit:            .string "exiting: ret, ra=";
-.size string_exit, .-string_exit
+	.data
+string_exit:			.string "exiting: ret, ra=";
+	.size string_exit, .-string_exit
 
-#endif /* WITH_CMD_X */
+	#endif /* WITH_CMD_X */

--- a/src/decode.S
+++ b/src/decode.S
@@ -1,376 +1,376 @@
-#include "vmon/config.h"
+	#include "vmon/config.h"
 
-#ifdef WITH_CMD_D
-
-
-.global insn_is_compressed
-
-.global print_instruction
-.global print_register_name
-.global print_rs1
-.global print_rs1_as_base
-.global print_rs2
-.global print_rd
-
-.global decode_opcode
-.global adjust_RVC_add_jal_ebreak
-
-.global decode_B_type
-.global decode_I_type
-.global decode_I_type_imm
-.global decode_I_type_LOAD
-.global decode_I_type_SHIFT
-.global decode_R_type
-.global decode_S_type
-.global decode_S_type_imm
-.global decode_U_type
-
-.global decode_JAL
-.global decode_JALR
-.global decode_CSR
-.global decode_CSRI
-.global decode_EBREAK
-.global decode_ECALL
-.global decode_WFI
-.global decode_MRET
-.global decode_SRET
-.global decode_SFENCE_VM
-.global decode_SFENCE_VMA
-.global decode_FENCE
-.global decode_FENCE_I
-.global decode_FENCE_TSO
-.global decode_AMO
-.global decode_LRSC
-.global decode_EMPTY
-
-#ifdef ENABLE_RVC
-.global decode_C_LWSP
-.global decode_C_ADD_JAL_EBREAK
-#endif
-
-.text
+	#ifdef WITH_CMD_D
 
 
-# evaluate if an instruction is an RVC instruction
-# in: instruction word in a0
-# out: a0=0 if not, nonzero if yes
+	.global insn_is_compressed
+
+	.global print_instruction
+	.global print_register_name
+	.global print_rs1
+	.global print_rs1_as_base
+	.global print_rs2
+	.global print_rd
+
+	.global decode_opcode
+	.global adjust_RVC_add_jal_ebreak
+
+	.global decode_B_type
+	.global decode_I_type
+	.global decode_I_type_imm
+	.global decode_I_type_LOAD
+	.global decode_I_type_SHIFT
+	.global decode_R_type
+	.global decode_S_type
+	.global decode_S_type_imm
+	.global decode_U_type
+
+	.global decode_JAL
+	.global decode_JALR
+	.global decode_CSR
+	.global decode_CSRI
+	.global decode_EBREAK
+	.global decode_ECALL
+	.global decode_WFI
+	.global decode_MRET
+	.global decode_SRET
+	.global decode_SFENCE_VM
+	.global decode_SFENCE_VMA
+	.global decode_FENCE
+	.global decode_FENCE_I
+	.global decode_FENCE_TSO
+	.global decode_AMO
+	.global decode_LRSC
+	.global decode_EMPTY
+
+	#ifdef ENABLE_RVC
+	.global decode_C_LWSP
+	.global decode_C_ADD_JAL_EBREAK
+	#endif
+
+	.text
+
+
+	# evaluate if an instruction is an RVC instruction
+	# in: instruction word in a0
+	# out: a0=0 if not, nonzero if yes
 insn_is_compressed:
-    andi    a0, a0, 0b11                 # look at bit 0 and 1
-    # uncompressed instructions have 0b11 in the end
-    li      t1, 0b11                
-    bne     a0, t1, insn_is_compressed_yes  # it is a compressed instruction
+	andi	a0, a0, 0b11				 # look at bit 0 and 1
+	# uncompressed instructions have 0b11 in the end
+	li		t1, 0b11				
+	bne		a0, t1, insn_is_compressed_yes	# it is a compressed instruction
 insn_is_compressed_no:
-    li      a0, 0
-    ret
+	li		a0, 0
+	ret
 insn_is_compressed_yes:
-    li      a0, 1
-    ret
-.size insn_is_compressed, .-insn_is_compressed
+	li		a0, 1
+	ret
+	.size insn_is_compressed, .-insn_is_compressed
 
 
-#ifdef ENABLE_RVA
-# for RVA
-# in: instruction word in a0
-# out: instruction word in a0
-# out: aq/rl bits in bits 0 and 1 of a1
+	#ifdef ENABLE_RVA
+	# for RVA
+	# in: instruction word in a0
+	# out: instruction word in a0
+	# out: aq/rl bits in bits 0 and 1 of a1
 insn_get_aqrl:
-    mv      a1, a0
-    li      t0, 0b11 
-    slli    t0, t0, 25
-    and     a1, t0, a1
-    srli    a1, a1, 25
-    ret
-.size insn_get_aqrl, .-insn_get_aqrl
-#endif
+	mv		a1, a0
+	li		t0, 0b11 
+	slli	t0, t0, 25
+	and		a1, t0, a1
+	srli	a1, a1, 25
+	ret
+	.size insn_get_aqrl, .-insn_get_aqrl
+	#endif
 
 
-# in: instruction word in a0
-# in: current instruction address in s5 (global)
+	# in: instruction word in a0
+	# in: current instruction address in s5 (global)
 decode_B_type:
-    addi    sp, sp, -(XLEN_BYTES*2)              
-    SAVE_X  ra, 0(sp)
-    SAVE_X  s2, (XLEN_BYTES*1)(sp)
-    mv      s2, a0   
-    jal     print_rs1
-    jal     print_comma
-    mv      a0, s2
-    jal     print_rs2
-    jal     print_comma
-    # imm[0] := 0
-    # inst[11:8] -> imm[4:1] 
-    srli    a0, s2, 7
-    andi    a0, a0, 0b11110
-    # inst[30:25] -> imm[10:5]
-    srli    t0, s2, 20
-    li      t1, 0b11111100000
-    and     t0, t0, t1
-    or      a0, a0, t0 
-    # inst[7] -> imm[11]
-    and     t0, s2, 0b10000000
-    slli    t0, t0, 4
-    or      a0, a0, t0 
-    # inst[31] -> imm[63:12]
-#if XLEN >=64
-    sext.w  s2, s2              # sign-extend to 64 bits
-#endif
-    srai    t0, s2, 19
-    li      t1, 0xfffffffffffff000          
-    and     t0, t0, t1
-    or      a0, a0, t0 
-    # add relative immediate to instruction address
-    add     a0, s5, a0
-    # print absolute target address
-    jal     print_hex  
-    LOAD_X  ra, 0(sp)               
-    LOAD_X  s2, (XLEN_BYTES*1)(sp)               
-    addi    sp, sp, (XLEN_BYTES*2)
-    ret
-.size decode_B_type, .-decode_B_type
+	addi	sp, sp, -(XLEN_BYTES*2)				 
+	SAVE_X	ra, 0(sp)
+	SAVE_X	s2, (XLEN_BYTES*1)(sp)
+	mv		s2, a0	 
+	jal		print_rs1
+	jal		print_comma
+	mv		a0, s2
+	jal		print_rs2
+	jal		print_comma
+	# imm[0] := 0
+	# inst[11:8] -> imm[4:1] 
+	srli	a0, s2, 7
+	andi	a0, a0, 0b11110
+	# inst[30:25] -> imm[10:5]
+	srli	t0, s2, 20
+	li		t1, 0b11111100000
+	and		t0, t0, t1
+	or		a0, a0, t0 
+	# inst[7] -> imm[11]
+	and		t0, s2, 0b10000000
+	slli	t0, t0, 4
+	or		a0, a0, t0 
+	# inst[31] -> imm[63:12]
+	#if XLEN >=64
+	sext.w	s2, s2				# sign-extend to 64 bits
+	#endif
+	srai	t0, s2, 19
+	li		t1, 0xfffffffffffff000			
+	and		t0, t0, t1
+	or		a0, a0, t0 
+	# add relative immediate to instruction address
+	add		a0, s5, a0
+	# print absolute target address
+	jal		print_hex  
+	LOAD_X	ra, 0(sp)				
+	LOAD_X	s2, (XLEN_BYTES*1)(sp)				 
+	addi	sp, sp, (XLEN_BYTES*2)
+	ret
+	.size decode_B_type, .-decode_B_type
 
 
-# in: instruction word in a0
+	# in: instruction word in a0
 decode_I_type:
-    addi    sp, sp, -(XLEN_BYTES*2)              
-    SAVE_X  ra, 0(sp)
-    SAVE_X  a0, (XLEN_BYTES*1)(sp)   
-    jal     print_rd
-    LOAD_X  a0, (XLEN_BYTES*1)(sp)               
-    jal     print_rs1
-    jal     print_comma
-    LOAD_X  a0, (XLEN_BYTES*1)(sp)               
-    jal     decode_I_type_imm
-    LOAD_X  ra, 0(sp)               
-    addi    sp, sp, (XLEN_BYTES*2)
-    ret
-.size decode_I_type, .-decode_I_type
+	addi	sp, sp, -(XLEN_BYTES*2)				 
+	SAVE_X	ra, 0(sp)
+	SAVE_X	a0, (XLEN_BYTES*1)(sp)	 
+	jal		print_rd
+	LOAD_X	a0, (XLEN_BYTES*1)(sp)				 
+	jal		print_rs1
+	jal		print_comma
+	LOAD_X	a0, (XLEN_BYTES*1)(sp)				 
+	jal		decode_I_type_imm
+	LOAD_X	ra, 0(sp)				
+	addi	sp, sp, (XLEN_BYTES*2)
+	ret
+	.size decode_I_type, .-decode_I_type
 
 
-# in: instruction word in a0
+	# in: instruction word in a0
 decode_I_type_imm:
-    addi    sp, sp, -(XLEN_BYTES*1)              
-    SAVE_X  ra, 0(sp)
-    # inst[31:20] -> imm[11:0]
-#if XLEN >=64
-    sext.w  a0, a0              # sign-extend to 64 bits
-#endif
-    srai    a0, a0, 20
-    jal     print_decimal
-    LOAD_X  ra, 0(sp)               
-    addi    sp, sp, (XLEN_BYTES*1)
-    ret
-.size decode_I_type_imm, .-decode_I_type_imm
+	addi	sp, sp, -(XLEN_BYTES*1)				 
+	SAVE_X	ra, 0(sp)
+	# inst[31:20] -> imm[11:0]
+	#if XLEN >=64
+	sext.w	a0, a0				# sign-extend to 64 bits
+	#endif
+	srai	a0, a0, 20
+	jal		print_decimal
+	LOAD_X	ra, 0(sp)				
+	addi	sp, sp, (XLEN_BYTES*1)
+	ret
+	.size decode_I_type_imm, .-decode_I_type_imm
 
 
-# in: instruction word in a0
+	# in: instruction word in a0
 decode_I_type_LOAD:
-    addi    sp, sp, -(XLEN_BYTES*2)              
-    SAVE_X  ra, 0(sp)
-    SAVE_X  s2, (XLEN_BYTES*1)(sp)      
-    mv      s2, a0
-    jal     print_rd
-    # inst[24:20] -> imm[5:0]
-#if XLEN >=64
-    sext.w  s2, s2              # sign-extend to 64 bits
-#endif
-    srai    a0, s2, 20
-    jal     print_decimal
-    mv      a0, s2
-    jal     print_rs1_as_base
-    LOAD_X  ra, 0(sp)               
-    LOAD_X  s2, (XLEN_BYTES*1)(sp)               
-    addi    sp, sp, (XLEN_BYTES*2)
-    ret
-.size decode_I_type_LOAD, .-decode_I_type_LOAD
+	addi	sp, sp, -(XLEN_BYTES*2)				 
+	SAVE_X	ra, 0(sp)
+	SAVE_X	s2, (XLEN_BYTES*1)(sp)		
+	mv		s2, a0
+	jal		print_rd
+	# inst[24:20] -> imm[5:0]
+	#if XLEN >=64
+	sext.w	s2, s2				# sign-extend to 64 bits
+	#endif
+	srai	a0, s2, 20
+	jal		print_decimal
+	mv		a0, s2
+	jal		print_rs1_as_base
+	LOAD_X	ra, 0(sp)				
+	LOAD_X	s2, (XLEN_BYTES*1)(sp)				 
+	addi	sp, sp, (XLEN_BYTES*2)
+	ret
+	.size decode_I_type_LOAD, .-decode_I_type_LOAD
 
 
-# in: instruction word in a0
+	# in: instruction word in a0
 decode_I_type_SHIFT:
-    addi    sp, sp, -(XLEN_BYTES*2)              
-    SAVE_X  ra, 0(sp)
-    SAVE_X  s2, (XLEN_BYTES*1)(sp)   
-    mv      s2, a0
-    jal     print_rd
-    mv      a0, s2
-    jal     print_rs1
-    jal     print_comma
-    # inst[24:20] -> imm[5:0]
-#if XLEN >=64
-    sext.w  s2, s2              # sign-extend to 64 bits
-#endif
-    srli    a0, s2, 20+6
-    jal     print_hex
-    LOAD_X  ra, 0(sp)               
-    LOAD_X  s2, (XLEN_BYTES*1)(sp)               
-    addi    sp, sp, (XLEN_BYTES*2)
-    ret
-.size decode_I_type_SHIFT, .-decode_I_type_SHIFT
+	addi	sp, sp, -(XLEN_BYTES*2)				 
+	SAVE_X	ra, 0(sp)
+	SAVE_X	s2, (XLEN_BYTES*1)(sp)	 
+	mv		s2, a0
+	jal		print_rd
+	mv		a0, s2
+	jal		print_rs1
+	jal		print_comma
+	# inst[24:20] -> imm[5:0]
+	#if XLEN >=64
+	sext.w	s2, s2				# sign-extend to 64 bits
+	#endif
+	srli	a0, s2, 20+6
+	jal		print_hex
+	LOAD_X	ra, 0(sp)				
+	LOAD_X	s2, (XLEN_BYTES*1)(sp)				 
+	addi	sp, sp, (XLEN_BYTES*2)
+	ret
+	.size decode_I_type_SHIFT, .-decode_I_type_SHIFT
 
 
-# in: instruction word in a0
+	# in: instruction word in a0
 decode_R_type:
-    addi    sp, sp, -(XLEN_BYTES*2)              
-    SAVE_X  ra, 0(sp)
-    SAVE_X  a0, (XLEN_BYTES*1)(sp) 
-    jal     print_rd
-    LOAD_X  a0, (XLEN_BYTES*1)(sp)               
-    jal     print_rs1
-    jal     print_comma
-    LOAD_X  a0, (XLEN_BYTES*1)(sp)               
-    jal     print_rs2
-    LOAD_X  ra, 0(sp)               
-    addi    sp, sp, (XLEN_BYTES*2)
-    ret
-.size decode_R_type, .-decode_R_type
+	addi	sp, sp, -(XLEN_BYTES*2)				 
+	SAVE_X	ra, 0(sp)
+	SAVE_X	a0, (XLEN_BYTES*1)(sp) 
+	jal		print_rd
+	LOAD_X	a0, (XLEN_BYTES*1)(sp)				 
+	jal		print_rs1
+	jal		print_comma
+	LOAD_X	a0, (XLEN_BYTES*1)(sp)				 
+	jal		print_rs2
+	LOAD_X	ra, 0(sp)				
+	addi	sp, sp, (XLEN_BYTES*2)
+	ret
+	.size decode_R_type, .-decode_R_type
 
 
-# in: instruction word in a0
+	# in: instruction word in a0
 decode_S_type:
-    addi    sp, sp, -(XLEN_BYTES*2)             
-    SAVE_X  ra, 0(sp)
-    SAVE_X  a0, (XLEN_BYTES*1)(sp)    
-    jal     ra, print_rs2
-    jal     print_comma
-    LOAD_X  a0, (XLEN_BYTES*1)(sp)               
-    jal     decode_S_type_imm
-    LOAD_X  a0, (XLEN_BYTES*1)(sp)               
-    jal     print_rs1_as_base
-    LOAD_X  ra, 0(sp)               
-    addi    sp, sp, (XLEN_BYTES*2)
-    ret
-.size decode_S_type, .-decode_S_type
+	addi	sp, sp, -(XLEN_BYTES*2)				
+	SAVE_X	ra, 0(sp)
+	SAVE_X	a0, (XLEN_BYTES*1)(sp)	  
+	jal		ra, print_rs2
+	jal		print_comma
+	LOAD_X	a0, (XLEN_BYTES*1)(sp)				 
+	jal		decode_S_type_imm
+	LOAD_X	a0, (XLEN_BYTES*1)(sp)				 
+	jal		print_rs1_as_base
+	LOAD_X	ra, 0(sp)				
+	addi	sp, sp, (XLEN_BYTES*2)
+	ret
+	.size decode_S_type, .-decode_S_type
 
 
-# in: instruction word in a0
+	# in: instruction word in a0
 decode_S_type_imm:
-    addi    sp, sp, -(XLEN_BYTES*1)             
-    SAVE_X  ra, 0(sp)
-    mv      t2, a0
-    # inst[11:7] -> imm[4:0]
-    srli    a0, t2, 7
-    andi    a0, a0, 0b11111 
-    # inst[30:25] -> imm[10:5]
-    srli    t0, t2, 20
-    li      t1, 0b11111100000
-    and     t0, t0, t1
-    or      a0, a0, t0 
-    # inst[31] -> imm[63:12]
-#if XLEN >=64
-    sext.w  t0, t2                          # sign-extend to 64 bits
-#endif
-    srai    t0, t0, 20
-    li      t1, 0xfffffffffffff800          
-    and     t0, t0, t1
-    or      a0, a0, t0 
-    jal     print_decimal
-    LOAD_X  ra, 0(sp)               
-    addi    sp, sp, (XLEN_BYTES*1)
-    ret
-.size decode_S_type_imm, .-decode_S_type_imm
+	addi	sp, sp, -(XLEN_BYTES*1)				
+	SAVE_X	ra, 0(sp)
+	mv		t2, a0
+	# inst[11:7] -> imm[4:0]
+	srli	a0, t2, 7
+	andi	a0, a0, 0b11111 
+	# inst[30:25] -> imm[10:5]
+	srli	t0, t2, 20
+	li		t1, 0b11111100000
+	and		t0, t0, t1
+	or		a0, a0, t0 
+	# inst[31] -> imm[63:12]
+	#if XLEN >=64
+	sext.w	t0, t2							# sign-extend to 64 bits
+	#endif
+	srai	t0, t0, 20
+	li		t1, 0xfffffffffffff800			
+	and		t0, t0, t1
+	or		a0, a0, t0 
+	jal		print_decimal
+	LOAD_X	ra, 0(sp)				
+	addi	sp, sp, (XLEN_BYTES*1)
+	ret
+	.size decode_S_type_imm, .-decode_S_type_imm
 
 
-# in: instruction word in a0
+	# in: instruction word in a0
 decode_U_type:
-    addi    sp, sp, -(XLEN_BYTES*2)              
-    SAVE_X  ra, 0(sp)
-    SAVE_X  s2, (XLEN_BYTES*1)(sp)  
-    mv      s2, a0    
-    jal     print_rd
-    # extract imm
-    li      t0, 0xffffffff
-    and     a0, s2, t0
-    srli    a0, a0, 12 
-    jal     print_hex
-    LOAD_X  ra, 0(sp)               
-    LOAD_X  s2, (XLEN_BYTES*1)(sp)               
-    addi    sp, sp, (XLEN_BYTES*2)
-    ret
-.size decode_U_type, .-decode_U_type
+	addi	sp, sp, -(XLEN_BYTES*2)				 
+	SAVE_X	ra, 0(sp)
+	SAVE_X	s2, (XLEN_BYTES*1)(sp)	
+	mv		s2, a0	  
+	jal		print_rd
+	# extract imm
+	li		t0, 0xffffffff
+	and		a0, s2, t0
+	srli	a0, a0, 12 
+	jal		print_hex
+	LOAD_X	ra, 0(sp)				
+	LOAD_X	s2, (XLEN_BYTES*1)(sp)				 
+	addi	sp, sp, (XLEN_BYTES*2)
+	ret
+	.size decode_U_type, .-decode_U_type
 
 
-# in: instruction word in a0
-# in: current instruction address in s5 (global)
+	# in: instruction word in a0
+	# in: current instruction address in s5 (global)
 decode_JAL:
-    addi    sp, sp, -(XLEN_BYTES*2)             
-    SAVE_X  ra, 0(sp)
-    SAVE_X  s2, (XLEN_BYTES*1)(sp)
-    mv      s2, a0
-    jal     print_rd  
-    # inst[30:21] -> imm[10:1]
-    srli    a0, s2, 20
-    andi    a0, a0, 0b11111111110    
-    # inst[20] -> imm[11]
-    srli    t0, s2, 9
-    li      t1, 0b100000000000 
-    and     t0, t0, t1
-    or      a0, a0, t0
-    # inst[19:12] -> imm[19:12]
-    li      t1, 0b11111111000000000000
-    and     t0, s2, t1
-    or      a0, a0, t0
-#if XLEN >=64
-    sext.w  s2, s2                          # sign-extend to 64 bits
-#endif
-    srai    t0, s2, 11
-    li      t1, 0xfffffffffff80000
-    and     t0, t0, t1
-    or      a0, a0, t0
+	addi	sp, sp, -(XLEN_BYTES*2)				
+	SAVE_X	ra, 0(sp)
+	SAVE_X	s2, (XLEN_BYTES*1)(sp)
+	mv		s2, a0
+	jal		print_rd  
+	# inst[30:21] -> imm[10:1]
+	srli	a0, s2, 20
+	andi	a0, a0, 0b11111111110	 
+	# inst[20] -> imm[11]
+	srli	t0, s2, 9
+	li		t1, 0b100000000000 
+	and		t0, t0, t1
+	or		a0, a0, t0
+	# inst[19:12] -> imm[19:12]
+	li		t1, 0b11111111000000000000
+	and		t0, s2, t1
+	or		a0, a0, t0
+	#if XLEN >=64
+	sext.w	s2, s2							# sign-extend to 64 bits
+	#endif
+	srai	t0, s2, 11
+	li		t1, 0xfffffffffff80000
+	and		t0, t0, t1
+	or		a0, a0, t0
 decode_JAL_add_offset:
-    add     a0, s5, a0
-    jal     print_hex
-    LOAD_X  ra, 0(sp)               
-    LOAD_X  s2, (XLEN_BYTES*1)(sp)               
-    addi    sp, sp, (XLEN_BYTES*2)
-    ret
-.size decode_JAL, .-decode_JAL
+	add		a0, s5, a0
+	jal		print_hex
+	LOAD_X	ra, 0(sp)				
+	LOAD_X	s2, (XLEN_BYTES*1)(sp)				 
+	addi	sp, sp, (XLEN_BYTES*2)
+	ret
+	.size decode_JAL, .-decode_JAL
 
-# in: a0: instruction word
-# in: a1: number of start bit (27 for pre, 23 for sucessor)
+	# in: a0: instruction word
+	# in: a1: number of start bit (27 for pre, 23 for sucessor)
 decode_FENCE_bits:
-    addi    sp, sp, -(XLEN_BYTES*5)             
-    SAVE_X  ra, 0(sp)
-    SAVE_X  s2, (XLEN_BYTES*1)(sp)
-    SAVE_X  s3, (XLEN_BYTES*2)(sp)
-    SAVE_X  s4, (XLEN_BYTES*3)(sp)
-    SAVE_X  s5, (XLEN_BYTES*4)(sp)
-    mv      s2, a0
-    li      s3, 1
-    sll     s3, s3, a1                      # set up initial bit mask
-    la      s4, string_FENCE_bits
-    li      s5, 4                           # 4 bits
+	addi	sp, sp, -(XLEN_BYTES*5)				
+	SAVE_X	ra, 0(sp)
+	SAVE_X	s2, (XLEN_BYTES*1)(sp)
+	SAVE_X	s3, (XLEN_BYTES*2)(sp)
+	SAVE_X	s4, (XLEN_BYTES*3)(sp)
+	SAVE_X	s5, (XLEN_BYTES*4)(sp)
+	mv		s2, a0
+	li		s3, 1
+	sll		s3, s3, a1						# set up initial bit mask
+	la		s4, string_FENCE_bits
+	li		s5, 4							# 4 bits
 decode_FENCE_bits_loop:
-    and     t0, s2, s3
-    beqz    t0, decode_FENCE_bits_skip
-    lb      a0, 0(s4)
-    jal     print_char
+	and		t0, s2, s3
+	beqz	t0, decode_FENCE_bits_skip
+	lb		a0, 0(s4)
+	jal		print_char
 decode_FENCE_bits_skip:
-    srli    s3, s3, 1
-    addi    s4, s4, 1
-    addi    s5, s5, -1
-    bnez    s5, decode_FENCE_bits_loop
-    LOAD_X  ra, 0(sp)               
-    LOAD_X  s2, (XLEN_BYTES*1)(sp)               
-    LOAD_X  s3, (XLEN_BYTES*2)(sp)               
-    LOAD_X  s4, (XLEN_BYTES*3)(sp)               
-    LOAD_X  s5, (XLEN_BYTES*4)(sp)               
-    addi    sp, sp, (XLEN_BYTES*5)
-    ret
-.size decode_FENCE_bits, .-decode_FENCE_bits
+	srli	s3, s3, 1
+	addi	s4, s4, 1
+	addi	s5, s5, -1
+	bnez	s5, decode_FENCE_bits_loop
+	LOAD_X	ra, 0(sp)				
+	LOAD_X	s2, (XLEN_BYTES*1)(sp)				 
+	LOAD_X	s3, (XLEN_BYTES*2)(sp)				 
+	LOAD_X	s4, (XLEN_BYTES*3)(sp)				 
+	LOAD_X	s5, (XLEN_BYTES*4)(sp)				 
+	addi	sp, sp, (XLEN_BYTES*5)
+	ret
+	.size decode_FENCE_bits, .-decode_FENCE_bits
 
 
 decode_FENCE:
-    addi    sp, sp, -(XLEN_BYTES*2)             
-    SAVE_X  ra, 0(sp)
-    SAVE_X  a0, (XLEN_BYTES*1)(sp)
-    li      a1, 27
-    jal     decode_FENCE_bits
-    jal     print_comma
-    LOAD_X  a0, (XLEN_BYTES*1)(sp)               
-    li      a1, 23
-    jal     decode_FENCE_bits
-    LOAD_X  ra, 0(sp)               
-    addi    sp, sp, (XLEN_BYTES*2)
-    ret
-.size decode_FENCE, .-decode_FENCE
+	addi	sp, sp, -(XLEN_BYTES*2)				
+	SAVE_X	ra, 0(sp)
+	SAVE_X	a0, (XLEN_BYTES*1)(sp)
+	li		a1, 27
+	jal		decode_FENCE_bits
+	jal		print_comma
+	LOAD_X	a0, (XLEN_BYTES*1)(sp)				 
+	li		a1, 23
+	jal		decode_FENCE_bits
+	LOAD_X	ra, 0(sp)				
+	addi	sp, sp, (XLEN_BYTES*2)
+	ret
+	.size decode_FENCE, .-decode_FENCE
 
 decode_C_ADD_JAL_EBREAK:
 decode_FENCE_I:
@@ -383,363 +383,363 @@ decode_SRET:
 decode_SFENCE_VM:
 decode_SFENCE_VMA:
 decode_EMPTY:
-    # do nothing
-    ret
-.size decode_FENCE_I, .-decode_FENCE_I
-.size decode_FENCE_TSO, .-decode_FENCE_TSO
-.size decode_ECALL, .-decode_ECALL
-.size decode_EBREAK, .-decode_EBREAK
-.size decode_EMPTY, .-decode_EMPTY
+	# do nothing
+	ret
+	.size decode_FENCE_I, .-decode_FENCE_I
+	.size decode_FENCE_TSO, .-decode_FENCE_TSO
+	.size decode_ECALL, .-decode_ECALL
+	.size decode_EBREAK, .-decode_EBREAK
+	.size decode_EMPTY, .-decode_EMPTY
 
 
-#ifdef ENABLE_RVA
+	#ifdef ENABLE_RVA
 decode_LRSC:
-    addi    sp, sp, -(XLEN_BYTES*2)              
-    SAVE_X  ra, 0(sp)
-    SAVE_X  a0, (XLEN_BYTES*1)(sp)  
-    jal     print_rd
-    LOAD_X  a0, (XLEN_BYTES*1)(sp)               
-    jal     print_rs2
-    jal     print_comma  
-    LOAD_X  a0, (XLEN_BYTES*1)(sp)               
-    jal     print_rs1_as_base
-    LOAD_X  ra, 0(sp)               
-    addi    sp, sp, (XLEN_BYTES*2)
-    ret
-.size decode_LRSC, .-decode_LRSC
+	addi	sp, sp, -(XLEN_BYTES*2)				 
+	SAVE_X	ra, 0(sp)
+	SAVE_X	a0, (XLEN_BYTES*1)(sp)	
+	jal		print_rd
+	LOAD_X	a0, (XLEN_BYTES*1)(sp)				 
+	jal		print_rs2
+	jal		print_comma	 
+	LOAD_X	a0, (XLEN_BYTES*1)(sp)				 
+	jal		print_rs1_as_base
+	LOAD_X	ra, 0(sp)				
+	addi	sp, sp, (XLEN_BYTES*2)
+	ret
+	.size decode_LRSC, .-decode_LRSC
 
 
-# in: instruction word in a0
+	# in: instruction word in a0
 decode_AMO:
-    addi    sp, sp, -(XLEN_BYTES*2)              
-    SAVE_X  ra, 0(sp)
-    SAVE_X  a0, (XLEN_BYTES*1)(sp)  
-    jal     print_rd
-    LOAD_X  a0, (XLEN_BYTES*1)(sp)               
-    jal     print_rs2
-    jal     print_comma  
-    # print rs1 = addr
-    LOAD_X  a0, (XLEN_BYTES*1)(sp)               
-    jal     print_rs1_as_base
-    LOAD_X  ra, 0(sp)               
-    addi    sp, sp, (XLEN_BYTES*2)
-    ret
-.size decode_AMO, .-decode_AMO
-#endif
+	addi	sp, sp, -(XLEN_BYTES*2)				 
+	SAVE_X	ra, 0(sp)
+	SAVE_X	a0, (XLEN_BYTES*1)(sp)	
+	jal		print_rd
+	LOAD_X	a0, (XLEN_BYTES*1)(sp)				 
+	jal		print_rs2
+	jal		print_comma	 
+	# print rs1 = addr
+	LOAD_X	a0, (XLEN_BYTES*1)(sp)				 
+	jal		print_rs1_as_base
+	LOAD_X	ra, 0(sp)				
+	addi	sp, sp, (XLEN_BYTES*2)
+	ret
+	.size decode_AMO, .-decode_AMO
+	#endif
 
 
-#ifdef ENABLE_RVC
-# in: instruction word in a0
+	#ifdef ENABLE_RVC
+	# in: instruction word in a0
 decode_CR_type:
-    # TODO
-    ret
-.size decode_CR_type, .-decode_CR_type
+	# TODO
+	ret
+	.size decode_CR_type, .-decode_CR_type
 
 
-# in: instruction word in a0
+	# in: instruction word in a0
 decode_C_LWSP:
-    addi    sp, sp, -(XLEN_BYTES*1)              
-    SAVE_X  ra, 0(sp)
-    jal     print_rd
-    li      a0, '('
-    jal     print_char
-    # TODO
-    li      a0, ')'
-    jal     print_char
-    LOAD_X  ra, 0(sp)               
-    addi    sp, sp, (XLEN_BYTES*1)
-    ret
-.size decode_C_LWSP, .-decode_C_LWSP
-#endif /* ENABLE_RVC */
+	addi	sp, sp, -(XLEN_BYTES*1)				 
+	SAVE_X	ra, 0(sp)
+	jal		print_rd
+	li		a0, '('
+	jal		print_char
+	# TODO
+	li		a0, ')'
+	jal		print_char
+	LOAD_X	ra, 0(sp)				
+	addi	sp, sp, (XLEN_BYTES*1)
+	ret
+	.size decode_C_LWSP, .-decode_C_LWSP
+	#endif /* ENABLE_RVC */
 
 
-# in: instruction word in a0
+	# in: instruction word in a0
 decode_CSR:
-    addi    sp, sp, -(XLEN_BYTES*2)              
-    SAVE_X  ra, 0(sp)
-    SAVE_X  a0, (XLEN_BYTES*1)(sp)     
-    jal     print_rd
-    LOAD_X  a0, (XLEN_BYTES*1)(sp)               
-    jal     print_csr
-    LOAD_X  a0, (XLEN_BYTES*1)(sp)               
-    jal     print_rs1    
-    LOAD_X  ra, 0(sp)               
-    addi    sp, sp, (XLEN_BYTES*2)
-    ret
-.size decode_CSR, .-decode_CSR
+	addi	sp, sp, -(XLEN_BYTES*2)				 
+	SAVE_X	ra, 0(sp)
+	SAVE_X	a0, (XLEN_BYTES*1)(sp)	   
+	jal		print_rd
+	LOAD_X	a0, (XLEN_BYTES*1)(sp)				 
+	jal		print_csr
+	LOAD_X	a0, (XLEN_BYTES*1)(sp)				 
+	jal		print_rs1	 
+	LOAD_X	ra, 0(sp)				
+	addi	sp, sp, (XLEN_BYTES*2)
+	ret
+	.size decode_CSR, .-decode_CSR
 
 
-# in: instruction word in a0
+	# in: instruction word in a0
 decode_CSRI:
-    addi    sp, sp, -(XLEN_BYTES*2)              
-    SAVE_X  ra, 0(sp)
-    SAVE_X  a0, (XLEN_BYTES*1)(sp)
-    jal     print_rd
-    LOAD_X  a0, (XLEN_BYTES*1)(sp)               
-    jal     print_csr
-    # extract uimm[4:0] 
-    LOAD_X  a0, (XLEN_BYTES*1)(sp)               
-    srli    a0, a0, 15
-    and     a0, a0, 0b11111
-    jal     print_decimal    
-    LOAD_X  ra, 0(sp)               
-    addi    sp, sp, (XLEN_BYTES*2)
-    ret
-.size decode_CSRI, .-decode_CSRI
+	addi	sp, sp, -(XLEN_BYTES*2)				 
+	SAVE_X	ra, 0(sp)
+	SAVE_X	a0, (XLEN_BYTES*1)(sp)
+	jal		print_rd
+	LOAD_X	a0, (XLEN_BYTES*1)(sp)				 
+	jal		print_csr
+	# extract uimm[4:0] 
+	LOAD_X	a0, (XLEN_BYTES*1)(sp)				 
+	srli	a0, a0, 15
+	and		a0, a0, 0b11111
+	jal		print_decimal	 
+	LOAD_X	ra, 0(sp)				
+	addi	sp, sp, (XLEN_BYTES*2)
+	ret
+	.size decode_CSRI, .-decode_CSRI
 
 
-# in: instruction word in a0
+	# in: instruction word in a0
 print_rd:
-    addi    sp, sp, -(XLEN_BYTES*1)              
-    SAVE_X  ra, 0(sp) 
-    # isolate rd from a0
-    srli    a0, a0, 7
-    andi    a0, a0, 0b11111
-    la      a1, int_register_names
-    jal     print_register_name
-    jal     print_comma
-    LOAD_X  ra, 0(sp)               
-    addi    sp, sp, (XLEN_BYTES*1)
-    ret
-.size print_rd, .-print_rd
+	addi	sp, sp, -(XLEN_BYTES*1)				 
+	SAVE_X	ra, 0(sp) 
+	# isolate rd from a0
+	srli	a0, a0, 7
+	andi	a0, a0, 0b11111
+	la		a1, int_register_names
+	jal		print_register_name
+	jal		print_comma
+	LOAD_X	ra, 0(sp)				
+	addi	sp, sp, (XLEN_BYTES*1)
+	ret
+	.size print_rd, .-print_rd
 
 
-# in: instruction word in a0
+	# in: instruction word in a0
 print_rs1:
-    addi    sp, sp, -(XLEN_BYTES*1)              
-    SAVE_X  ra, 0(sp) 
-    srli    a0, a0, 15
-    and     a0, a0, 0b11111
-    la      a1, int_register_names
-    jal     print_register_name
-    LOAD_X  ra, 0(sp)               
-    addi    sp, sp, (XLEN_BYTES*1)
-    ret
-.size print_rs1, .-print_rs1
+	addi	sp, sp, -(XLEN_BYTES*1)				 
+	SAVE_X	ra, 0(sp) 
+	srli	a0, a0, 15
+	and		a0, a0, 0b11111
+	la		a1, int_register_names
+	jal		print_register_name
+	LOAD_X	ra, 0(sp)				
+	addi	sp, sp, (XLEN_BYTES*1)
+	ret
+	.size print_rs1, .-print_rs1
 
 
-# in: instruction word in a0
+	# in: instruction word in a0
 print_rs1_as_base:
-    addi    sp, sp, -(XLEN_BYTES*2)              
-    SAVE_X  ra, 0(sp)
-    SAVE_X  a0, (XLEN_BYTES*1)(sp)   
-    li      a0, '('
-    jal     print_char
-    LOAD_X  a0, (XLEN_BYTES*1)(sp)               
-    jal     print_rs1
-    li      a0, ')'
-    jal     print_char
-    LOAD_X  ra, 0(sp)               
-    addi    sp, sp, (XLEN_BYTES*2)
-    ret
-.size print_rs1, .-print_rs1
+	addi	sp, sp, -(XLEN_BYTES*2)				 
+	SAVE_X	ra, 0(sp)
+	SAVE_X	a0, (XLEN_BYTES*1)(sp)	 
+	li		a0, '('
+	jal		print_char
+	LOAD_X	a0, (XLEN_BYTES*1)(sp)				 
+	jal		print_rs1
+	li		a0, ')'
+	jal		print_char
+	LOAD_X	ra, 0(sp)				
+	addi	sp, sp, (XLEN_BYTES*2)
+	ret
+	.size print_rs1, .-print_rs1
 
 
-# in: instruction word in a0
+	# in: instruction word in a0
 print_rs2:
-    # rs2 just needs 5 shifts more than rs1, rest works the same
-    srli    a0, a0, 5           
-    j       print_rs1  
-.size print_rs2, .-print_rs2
+	# rs2 just needs 5 shifts more than rs1, rest works the same
+	srli	a0, a0, 5			
+	j		print_rs1  
+	.size print_rs2, .-print_rs2
 
 
-# in: instruction word in a0
+	# in: instruction word in a0
 print_csr:
-    addi    sp, sp, -(XLEN_BYTES*1)              
-    SAVE_X  ra, 0(sp) 
-    srai    a0, a0, 20
-    li      t0, 0b111111111111
-    and     a0, a0, t0
-    jal     print_hex
-    jal     print_comma
-    LOAD_X  ra, 0(sp)               
-    addi    sp, sp, (XLEN_BYTES*1)
-    ret
-.size print_csr, .-print_csr
+	addi	sp, sp, -(XLEN_BYTES*1)				 
+	SAVE_X	ra, 0(sp) 
+	srai	a0, a0, 20
+	li		t0, 0b111111111111
+	and		a0, a0, t0
+	jal		print_hex
+	jal		print_comma
+	LOAD_X	ra, 0(sp)				
+	addi	sp, sp, (XLEN_BYTES*1)
+	ret
+	.size print_csr, .-print_csr
 
 
-# output the n-th register name from the register name table
-# in: n in a0
+	# output the n-th register name from the register name table
+	# in: n in a0
 print_register_name:
-    addi    sp, sp, -(XLEN_BYTES*2)              
-    SAVE_X  ra, 0(sp)
-    SAVE_X  s0, (XLEN_BYTES*1)(sp)
-    mv      s0, a1
+	addi	sp, sp, -(XLEN_BYTES*2)				 
+	SAVE_X	ra, 0(sp)
+	SAVE_X	s0, (XLEN_BYTES*1)(sp)
+	mv		s0, a1
 print_register_search:
-    beqz    a0, print_register_found
-    addi    s0, s0, 1
-print_register_skip_next_zero:    
-    lb      t1, 0(s0)
-    beqz    t1, print_register_next_zero
-    addi    s0, s0, 1
-    j       print_register_skip_next_zero
+	beqz	a0, print_register_found
+	addi	s0, s0, 1
+print_register_skip_next_zero:	  
+	lb		t1, 0(s0)
+	beqz	t1, print_register_next_zero
+	addi	s0, s0, 1
+	j		print_register_skip_next_zero
 print_register_next_zero:
-    addi    a0, a0, -1
-    addi    s0, s0, 1
-    j       print_register_search
- print_register_found:
-    mv      a0, s0
-    jal     print_string
-    LOAD_X  ra, 0(sp)               
-    LOAD_X  s0, (XLEN_BYTES*1)(sp)               
-    addi    sp, sp, (XLEN_BYTES*2)
-    ret
-.size print_register_name, .-print_register_name
+	addi	a0, a0, -1
+	addi	s0, s0, 1
+	j		print_register_search
+print_register_found:
+	mv		a0, s0
+	jal		print_string
+	LOAD_X	ra, 0(sp)				
+	LOAD_X	s0, (XLEN_BYTES*1)(sp)				 
+	addi	sp, sp, (XLEN_BYTES*2)
+	ret
+	.size print_register_name, .-print_register_name
 
 
-# in: instruction word in a0
-# out: instruction word in a0
-# out: type-depending decode function ptr in a1
-# out: opcode string in a2
+	# in: instruction word in a0
+	# out: instruction word in a0
+	# out: type-depending decode function ptr in a1
+	# out: opcode string in a2
 decode_opcode:
-    addi    sp, sp, -(XLEN_BYTES*1)              
-    SAVE_X  ra, 0(sp)
-    # search for a match in encoding table
-    la      t0, encoding_table
-    # clear return values
-    mv      a1, zero
-    mv      a2, zero
+	addi	sp, sp, -(XLEN_BYTES*1)				 
+	SAVE_X	ra, 0(sp)
+	# search for a match in encoding table
+	la		t0, encoding_table
+	# clear return values
+	mv		a1, zero
+	mv		a2, zero
 decode_opcode_search_next:
-#if XLEN >= 64
-    lwu     t2, 0(t0)                       # get mask word from table
-#else
-    lw      t2, 0(t0)                       # get mask word from table
-#endif
-    beqz    t2, decode_opcode_done          # table end, no match found   
-    and     t2, a0, t2                      # apply mask
-#if XLEN >= 64
-    lwu     t3, 4(t0)                       # get match word from table
-#else
-    lw      t3, 4(t0)                       # get match word from table
-#endif
-    bne     t2, t3, decode_opcode_continue
-    # found a match
-#if XLEN >=64
-    lwu     a1, 8(t0)                       # get function ptr from table
-    lwu     a2, 12(t0)                      # get string ptr from table
-#else
-    lw      a1, 8(t0)                       # get function ptr from table
-    lw      a2, 12(t0)                      # get string ptr from table
-#endif
-    j       decode_opcode_done
+	#if XLEN >= 64
+	lwu		t2, 0(t0)						# get mask word from table
+	#else
+	lw		t2, 0(t0)						# get mask word from table
+	#endif
+	beqz	t2, decode_opcode_done			# table end, no match found	  
+	and		t2, a0, t2						# apply mask
+	#if XLEN >= 64
+	lwu		t3, 4(t0)						# get match word from table
+	#else
+	lw		t3, 4(t0)						# get match word from table
+	#endif
+	bne		t2, t3, decode_opcode_continue
+	# found a match
+	#if XLEN >=64
+	lwu		a1, 8(t0)						# get function ptr from table
+	lwu		a2, 12(t0)						# get string ptr from table
+	#else
+	lw		a1, 8(t0)						# get function ptr from table
+	lw		a2, 12(t0)						# get string ptr from table
+	#endif
+	j		decode_opcode_done
 decode_opcode_continue:
-    addi    t0, t0, 20                      # point to next table entry
-    j       decode_opcode_search_next       # repeat
+	addi	t0, t0, 20						# point to next table entry
+	j		decode_opcode_search_next		# repeat
 decode_opcode_done:
-    LOAD_X  ra, 0(sp)          
-    addi    sp, sp, (XLEN_BYTES*1)
-    ret
-.size decode_opcode, .-decode_opcode
+	LOAD_X	ra, 0(sp)		   
+	addi	sp, sp, (XLEN_BYTES*1)
+	ret
+	.size decode_opcode, .-decode_opcode
 
-#ifdef ENABLE_RVC
-# c.add, c.ebreak and c.jalr cannot be correctly identified by MATCH/MASK alone
-# so this routine fixes that after calling decode_opcode
-#
-# in: instruction word in a0
-# in: type-depending decoder routine to call in a1
-# in: opcode string in a2
-# out: instruction word in a0
-# out: type-depending decoder routine to call in a1
-# out: opcode string in a2
+	#ifdef ENABLE_RVC
+	# c.add, c.ebreak and c.jalr cannot be correctly identified by MATCH/MASK alone
+	# so this routine fixes that after calling decode_opcode
+	#
+	# in: instruction word in a0
+	# in: type-depending decoder routine to call in a1
+	# in: opcode string in a2
+	# out: instruction word in a0
+	# out: type-depending decoder routine to call in a1
+	# out: opcode string in a2
 adjust_RVC_add_jal_ebreak:
-    li      t0, 0x9002
-    bne     a0, t0, adjust_RVC_add_jal_ebreak_not_ebreak
-    # c.ebreak
-    la      a1, decode_EMPTY
-    la      a2, string_OP_C_EBREAK
-    ret
+	li		t0, 0x9002
+	bne		a0, t0, adjust_RVC_add_jal_ebreak_not_ebreak
+	# c.ebreak
+	la		a1, decode_EMPTY
+	la		a2, string_OP_C_EBREAK
+	ret
 adjust_RVC_add_jal_ebreak_not_ebreak:
-    # TODO c.add
-    ret
+	# TODO c.add
+	ret
 adjust_RVC_add_jal_ebreak_not_add:
-    # TODO c.jalr
-    ret
+	# TODO c.jalr
+	ret
 adjust_RVC_add_jal_ebreak_done:
-    ret
-.size adjust_RVC_add_jal_ebreak, .-adjust_RVC_add_jal_ebreak
-#endif
+	ret
+	.size adjust_RVC_add_jal_ebreak, .-adjust_RVC_add_jal_ebreak
+	#endif
 
 
-# in: instruction word in a0
-# in: type-depending decoder routine to call in a1
-# in: opcode string in a2
+	# in: instruction word in a0
+	# in: type-depending decoder routine to call in a1
+	# in: opcode string in a2
 print_instruction:
-    addi    sp, sp, -(XLEN_BYTES*3)              
-    SAVE_X  ra, 0(sp)
-    SAVE_X  s2, (XLEN_BYTES*1)(sp)
-    SAVE_X  s3, (XLEN_BYTES*2)(sp)    
-    mv      s2, a1                  # save for later
-    mv      s3, a0                  # save for later    
-    mv      a0, a2
-    jal     print_string            # print opcode
-#ifdef ENABLE_RVA
-    mv      a0, s3
-    jal     print_AMO_postfix       # prints aq/lr postfix for RVA opcodes
-#endif
-    la      a0, string_asm_sep2
-    jal     print_string
-    # call decoder routine (only if address is non-zero)
-    beqz    s2, print_instruction_done  
-    mv      a0, s3
-    jalr    s2                      # execute call
+	addi	sp, sp, -(XLEN_BYTES*3)				 
+	SAVE_X	ra, 0(sp)
+	SAVE_X	s2, (XLEN_BYTES*1)(sp)
+	SAVE_X	s3, (XLEN_BYTES*2)(sp)	  
+	mv		s2, a1					# save for later
+	mv		s3, a0					# save for later	
+	mv		a0, a2
+	jal		print_string			# print opcode
+	#ifdef ENABLE_RVA
+	mv		a0, s3
+	jal		print_AMO_postfix		# prints aq/lr postfix for RVA opcodes
+	#endif
+	la		a0, string_asm_sep2
+	jal		print_string
+	# call decoder routine (only if address is non-zero)
+	beqz	s2, print_instruction_done	
+	mv		a0, s3
+	jalr	s2						# execute call
 print_instruction_done:
-    LOAD_X  ra, 0(sp)               
-    LOAD_X  s2, (XLEN_BYTES*1)(sp)   
-    LOAD_X  s3, (XLEN_BYTES*2)(sp)     
-    addi    sp, sp, (XLEN_BYTES*3)
-    ret
-.size print_instruction, .-print_instruction
+	LOAD_X	ra, 0(sp)				
+	LOAD_X	s2, (XLEN_BYTES*1)(sp)	 
+	LOAD_X	s3, (XLEN_BYTES*2)(sp)	   
+	addi	sp, sp, (XLEN_BYTES*3)
+	ret
+	.size print_instruction, .-print_instruction
 
 
-#ifdef ENABLE_RVA
-# in: instruction word in a0
+	#ifdef ENABLE_RVA
+	# in: instruction word in a0
 print_AMO_postfix:
-    addi    sp, sp, -(XLEN_BYTES*1)              
-    SAVE_X  ra, 0(sp)
-    # check if bits 0-6 are an AMO opcode, return if not
-    li      t0, 0x7f            # MASK
-    and     t1, a0, t0
-    li      t2, 0x2f            # MATCH
-    bne     t1, t2, print_AMO_postfix_done
-    # decode ac/rl bits and print fitting postfix
-    jal     insn_get_aqrl
-    beqz    a1, print_AMO_postfix_done
-    li      t0, 1
-    bne     a1, t0, print_AMO_postfix_case2
-    la      a0, string_OP_POSTFIX_RL
-    jal     print_string
-    j       print_AMO_postfix_done
+	addi	sp, sp, -(XLEN_BYTES*1)				 
+	SAVE_X	ra, 0(sp)
+	# check if bits 0-6 are an AMO opcode, return if not
+	li		t0, 0x7f			# MASK
+	and		t1, a0, t0
+	li		t2, 0x2f			# MATCH
+	bne		t1, t2, print_AMO_postfix_done
+	# decode ac/rl bits and print fitting postfix
+	jal		insn_get_aqrl
+	beqz	a1, print_AMO_postfix_done
+	li		t0, 1
+	bne		a1, t0, print_AMO_postfix_case2
+	la		a0, string_OP_POSTFIX_RL
+	jal		print_string
+	j		print_AMO_postfix_done
 print_AMO_postfix_case2:
-    li      t0, 2
-    bne     a1, t0, print_AMO_postfix_case3
-    la      a0, string_OP_POSTFIX_AQ
-    jal     print_string
-    j       print_AMO_postfix_done
+	li		t0, 2
+	bne		a1, t0, print_AMO_postfix_case3
+	la		a0, string_OP_POSTFIX_AQ
+	jal		print_string
+	j		print_AMO_postfix_done
 print_AMO_postfix_case3:
-    la      a0, string_OP_POSTFIX_AQRL
-    jal     print_string
-print_AMO_postfix_done:    
-    LOAD_X  ra, 0(sp)               
-    addi    sp, sp, (XLEN_BYTES*1)
-    ret
-.size print_AMO_postfix, .-print_AMO_postfix
-#endif
+	la		a0, string_OP_POSTFIX_AQRL
+	jal		print_string
+print_AMO_postfix_done:	   
+	LOAD_X	ra, 0(sp)				
+	addi	sp, sp, (XLEN_BYTES*1)
+	ret
+	.size print_AMO_postfix, .-print_AMO_postfix
+	#endif
 
 
-.data
+	.data
 
-.align 4
+	.align 4
 
-string_FENCE_bits:      .string "iorw";
+string_FENCE_bits:		.string "iorw";
 
-#ifdef ENABLE_RVA
-    string_OP_POSTFIX_AQ:   .string ".aq";
-    .size string_OP_POSTFIX_AQ, .-string_OP_POSTFIX_AQ
-    string_OP_POSTFIX_RL:	.string ".rl";
-    .size string_OP_POSTFIX_RL, .-string_OP_POSTFIX_RL
-    string_OP_POSTFIX_AQRL:	.string ".aqrl";
-    .size string_OP_POSTFIX_AQRL, .-string_OP_POSTFIX_AQRL
-#endif
+	#ifdef ENABLE_RVA
+string_OP_POSTFIX_AQ:	.string ".aq";
+	.size string_OP_POSTFIX_AQ, .-string_OP_POSTFIX_AQ
+string_OP_POSTFIX_RL:	.string ".rl";
+	.size string_OP_POSTFIX_RL, .-string_OP_POSTFIX_RL
+string_OP_POSTFIX_AQRL:	.string ".aqrl";
+	.size string_OP_POSTFIX_AQRL, .-string_OP_POSTFIX_AQRL
+	#endif
 
 
-#endif /* WITH_CMD_D */
+	#endif /* WITH_CMD_D */

--- a/src/decode_F.S
+++ b/src/decode_F.S
@@ -1,203 +1,203 @@
-#include "vmon/config.h"
+	#include "vmon/config.h"
 
-#ifdef WITH_CMD_D
+	#ifdef WITH_CMD_D
 
-#ifdef ENABLE_RVF
+	#ifdef ENABLE_RVF
 
-.global decode_FL
-.global decode_FS
-.global decode_FADD
-.global decode_FSQRT
-.global decode_FMA
-.global decode_FCVT_SW
-.global decode_FCVT_WS
-.global decode_FCMP
-.global decode_FCLASS
+	.global decode_FL
+	.global decode_FS
+	.global decode_FADD
+	.global decode_FSQRT
+	.global decode_FMA
+	.global decode_FCVT_SW
+	.global decode_FCVT_WS
+	.global decode_FCMP
+	.global decode_FCLASS
 
 
-.text
+	.text
 
-# in: instruction word in a0
+	# in: instruction word in a0
 print_frd:
-    addi    sp, sp, -(XLEN_BYTES*1)              
-    SAVE_X  ra, 0(sp) 
-    srli    a0, a0, 7
-    andi    a0, a0, 0b11111
-    la      a1, float_register_names
-    jal     print_register_name
-    jal     print_comma
-    LOAD_X  ra, 0(sp)               
-    addi    sp, sp, (XLEN_BYTES*1)
-    ret
-.size print_frd, .-print_frd
+	addi	sp, sp, -(XLEN_BYTES*1)				 
+	SAVE_X	ra, 0(sp) 
+	srli	a0, a0, 7
+	andi	a0, a0, 0b11111
+	la		a1, float_register_names
+	jal		print_register_name
+	jal		print_comma
+	LOAD_X	ra, 0(sp)				
+	addi	sp, sp, (XLEN_BYTES*1)
+	ret
+	.size print_frd, .-print_frd
 
 
-# in: instruction word in a0
+	# in: instruction word in a0
 print_frs1:
-    addi    sp, sp, -(XLEN_BYTES*1)              
-    SAVE_X  ra, 0(sp) 
-    srli    a0, a0, 15
-    and     a0, a0, 0b11111
-    la      a1, float_register_names
-    jal     print_register_name
-    LOAD_X  ra, 0(sp)               
-    addi    sp, sp, (XLEN_BYTES*1)
-    ret
-.size print_frs1, .-print_frs1
+	addi	sp, sp, -(XLEN_BYTES*1)				 
+	SAVE_X	ra, 0(sp) 
+	srli	a0, a0, 15
+	and		a0, a0, 0b11111
+	la		a1, float_register_names
+	jal		print_register_name
+	LOAD_X	ra, 0(sp)				
+	addi	sp, sp, (XLEN_BYTES*1)
+	ret
+	.size print_frs1, .-print_frs1
 
 
-# in: instruction word in a0
+	# in: instruction word in a0
 print_frs2:
-    # rs2 just needs 5 shifts more than rs1, rest works the same
-    srli    a0, a0, 5           
-    j       print_frs1  
-.size print_frs2, .-print_frs2
+	# rs2 just needs 5 shifts more than rs1, rest works the same
+	srli	a0, a0, 5			
+	j		print_frs1	
+	.size print_frs2, .-print_frs2
 
 
-# in: instruction word in a0
+	# in: instruction word in a0
 print_frs3:
-    # rs2 just needs 5 shifts more than rs1, rest works the same
-    srli    a0, a0, 12           
-    j       print_frs1  
-.size print_frs3, .-print_frs3
+	# rs2 just needs 5 shifts more than rs1, rest works the same
+	srli	a0, a0, 12			 
+	j		print_frs1	
+	.size print_frs3, .-print_frs3
 
 
-# in: instruction word in a0
+	# in: instruction word in a0
 decode_FL:
-    addi    sp, sp, -(XLEN_BYTES*2)              
-    SAVE_X  ra, 0(sp)
-    SAVE_X  a0, (XLEN_BYTES*1)(sp) 
-    jal     print_frd
-    LOAD_X  a0, (XLEN_BYTES*1)(sp)               
-    jal     decode_I_type_imm
-    LOAD_X  a0, (XLEN_BYTES*1)(sp)               
-    jal     print_rs1_as_base
-    LOAD_X  ra, 0(sp)               
-    addi    sp, sp, (XLEN_BYTES*2)
-    ret
-.size decode_FL, .-decode_FL
+	addi	sp, sp, -(XLEN_BYTES*2)				 
+	SAVE_X	ra, 0(sp)
+	SAVE_X	a0, (XLEN_BYTES*1)(sp) 
+	jal		print_frd
+	LOAD_X	a0, (XLEN_BYTES*1)(sp)				 
+	jal		decode_I_type_imm
+	LOAD_X	a0, (XLEN_BYTES*1)(sp)				 
+	jal		print_rs1_as_base
+	LOAD_X	ra, 0(sp)				
+	addi	sp, sp, (XLEN_BYTES*2)
+	ret
+	.size decode_FL, .-decode_FL
 
 
-# TODO: can be joined with decode_S_type
-# in: instruction word in a0
+	# TODO: can be joined with decode_S_type
+	# in: instruction word in a0
 decode_FS:
-    addi    sp, sp, -(XLEN_BYTES*2)              
-    SAVE_X  ra, 0(sp)
-    SAVE_X  a0, (XLEN_BYTES*1)(sp) 
-    jal     print_frs2
-    jal     print_comma
-    LOAD_X  a0, (XLEN_BYTES*1)(sp)               
-    jal     decode_S_type_imm
-    LOAD_X  a0, (XLEN_BYTES*1)(sp)               
-    jal     print_rs1_as_base
-    LOAD_X  ra, 0(sp)               
-    addi    sp, sp, (XLEN_BYTES*2)
-    ret
-.size decode_FS, .-decode_FS
+	addi	sp, sp, -(XLEN_BYTES*2)				 
+	SAVE_X	ra, 0(sp)
+	SAVE_X	a0, (XLEN_BYTES*1)(sp) 
+	jal		print_frs2
+	jal		print_comma
+	LOAD_X	a0, (XLEN_BYTES*1)(sp)				 
+	jal		decode_S_type_imm
+	LOAD_X	a0, (XLEN_BYTES*1)(sp)				 
+	jal		print_rs1_as_base
+	LOAD_X	ra, 0(sp)				
+	addi	sp, sp, (XLEN_BYTES*2)
+	ret
+	.size decode_FS, .-decode_FS
 
 
-# in: instruction word in a0
+	# in: instruction word in a0
 decode_FADD:
-    addi    sp, sp, -(XLEN_BYTES*2)              
-    SAVE_X  ra, 0(sp)
-    SAVE_X  a0, (XLEN_BYTES*1)(sp) 
-    jal     print_frd
-    LOAD_X  a0, (XLEN_BYTES*1)(sp)               
-    jal     print_frs1
-    jal     print_comma
-    LOAD_X  a0, (XLEN_BYTES*1)(sp)               
-    jal     print_frs2
-    LOAD_X  ra, 0(sp)               
-    addi    sp, sp, (XLEN_BYTES*2)
-    ret
-.size decode_FADD, .-decode_FADD
+	addi	sp, sp, -(XLEN_BYTES*2)				 
+	SAVE_X	ra, 0(sp)
+	SAVE_X	a0, (XLEN_BYTES*1)(sp) 
+	jal		print_frd
+	LOAD_X	a0, (XLEN_BYTES*1)(sp)				 
+	jal		print_frs1
+	jal		print_comma
+	LOAD_X	a0, (XLEN_BYTES*1)(sp)				 
+	jal		print_frs2
+	LOAD_X	ra, 0(sp)				
+	addi	sp, sp, (XLEN_BYTES*2)
+	ret
+	.size decode_FADD, .-decode_FADD
 
 
-# in: instruction word in a0
+	# in: instruction word in a0
 decode_FMA:
-    addi    sp, sp, -(XLEN_BYTES*2)              
-    SAVE_X  ra, 0(sp)
-    SAVE_X  a0, (XLEN_BYTES*1)(sp) 
-    jal     decode_FADD
-    jal     print_comma
-    LOAD_X  a0, (XLEN_BYTES*1)(sp)               
-    jal     print_frs3
-    LOAD_X  ra, 0(sp)               
-    addi    sp, sp, (XLEN_BYTES*2)
-    ret
-.size decode_FMA, .-decode_FMA
+	addi	sp, sp, -(XLEN_BYTES*2)				 
+	SAVE_X	ra, 0(sp)
+	SAVE_X	a0, (XLEN_BYTES*1)(sp) 
+	jal		decode_FADD
+	jal		print_comma
+	LOAD_X	a0, (XLEN_BYTES*1)(sp)				 
+	jal		print_frs3
+	LOAD_X	ra, 0(sp)				
+	addi	sp, sp, (XLEN_BYTES*2)
+	ret
+	.size decode_FMA, .-decode_FMA
 
 
-# in: instruction word in a0
+	# in: instruction word in a0
 decode_FSQRT:
-    addi    sp, sp, -(XLEN_BYTES*2)              
-    SAVE_X  ra, 0(sp)
-    SAVE_X  a0, (XLEN_BYTES*1)(sp) 
-    jal     print_frd
-    LOAD_X  a0, (XLEN_BYTES*1)(sp)               
-    jal     print_frs1
-    LOAD_X  ra, 0(sp)               
-    addi    sp, sp, (XLEN_BYTES*2)
-    ret
-.size decode_FSQRT, .-decode_FSQRT
+	addi	sp, sp, -(XLEN_BYTES*2)				 
+	SAVE_X	ra, 0(sp)
+	SAVE_X	a0, (XLEN_BYTES*1)(sp) 
+	jal		print_frd
+	LOAD_X	a0, (XLEN_BYTES*1)(sp)				 
+	jal		print_frs1
+	LOAD_X	ra, 0(sp)				
+	addi	sp, sp, (XLEN_BYTES*2)
+	ret
+	.size decode_FSQRT, .-decode_FSQRT
 
 
-# in: instruction word in a0
+	# in: instruction word in a0
 decode_FCVT_SW:
-    addi    sp, sp, -(XLEN_BYTES*2)              
-    SAVE_X  ra, 0(sp)
-    SAVE_X  a0, (XLEN_BYTES*1)(sp) 
-    jal     print_frd
-    LOAD_X  a0, (XLEN_BYTES*1)(sp)               
-    jal     print_rs1
-    LOAD_X  ra, 0(sp)               
-    addi    sp, sp, (XLEN_BYTES*2)
-    ret
-.size decode_FCVT_SW, .-decode_FCVT_SW
+	addi	sp, sp, -(XLEN_BYTES*2)				 
+	SAVE_X	ra, 0(sp)
+	SAVE_X	a0, (XLEN_BYTES*1)(sp) 
+	jal		print_frd
+	LOAD_X	a0, (XLEN_BYTES*1)(sp)				 
+	jal		print_rs1
+	LOAD_X	ra, 0(sp)				
+	addi	sp, sp, (XLEN_BYTES*2)
+	ret
+	.size decode_FCVT_SW, .-decode_FCVT_SW
 
 
 decode_FCVT_WS:
-    addi    sp, sp, -(XLEN_BYTES*2)              
-    SAVE_X  ra, 0(sp)
-    SAVE_X  a0, (XLEN_BYTES*1)(sp) 
-    jal     print_rd
-    LOAD_X  a0, (XLEN_BYTES*1)(sp)               
-    jal     print_frs1
-    LOAD_X  ra, 0(sp)               
-    addi    sp, sp, (XLEN_BYTES*2)
-    ret
-.size decode_FCVT_WS, .-decode_FCVT_WS
+	addi	sp, sp, -(XLEN_BYTES*2)				 
+	SAVE_X	ra, 0(sp)
+	SAVE_X	a0, (XLEN_BYTES*1)(sp) 
+	jal		print_rd
+	LOAD_X	a0, (XLEN_BYTES*1)(sp)				 
+	jal		print_frs1
+	LOAD_X	ra, 0(sp)				
+	addi	sp, sp, (XLEN_BYTES*2)
+	ret
+	.size decode_FCVT_WS, .-decode_FCVT_WS
 
 
 decode_FCLASS:
-    addi    sp, sp, -(XLEN_BYTES*2)              
-    SAVE_X  ra, 0(sp)
-    SAVE_X  a0, (XLEN_BYTES*1)(sp) 
-    jal     print_rd
-    LOAD_X  a0, (XLEN_BYTES*1)(sp)               
-    jal     print_frs1
-    LOAD_X  ra, 0(sp)               
-    addi    sp, sp, (XLEN_BYTES*2)
-    ret
-.size decode_FCLASS, .-decode_FCLASS
+	addi	sp, sp, -(XLEN_BYTES*2)				 
+	SAVE_X	ra, 0(sp)
+	SAVE_X	a0, (XLEN_BYTES*1)(sp) 
+	jal		print_rd
+	LOAD_X	a0, (XLEN_BYTES*1)(sp)				 
+	jal		print_frs1
+	LOAD_X	ra, 0(sp)				
+	addi	sp, sp, (XLEN_BYTES*2)
+	ret
+	.size decode_FCLASS, .-decode_FCLASS
 
 
 decode_FCMP:
-    addi    sp, sp, -(XLEN_BYTES*2)              
-    SAVE_X  ra, 0(sp)
-    SAVE_X  a0, (XLEN_BYTES*1)(sp) 
-    jal     decode_FCLASS
-    jal     print_comma
-    LOAD_X  a0, (XLEN_BYTES*1)(sp)               
-    jal     print_frs2
-    LOAD_X  ra, 0(sp)               
-    addi    sp, sp, (XLEN_BYTES*2)
-    ret
-.size decode_FCMP, .-decode_FCMP
+	addi	sp, sp, -(XLEN_BYTES*2)				 
+	SAVE_X	ra, 0(sp)
+	SAVE_X	a0, (XLEN_BYTES*1)(sp) 
+	jal		decode_FCLASS
+	jal		print_comma
+	LOAD_X	a0, (XLEN_BYTES*1)(sp)				 
+	jal		print_frs2
+	LOAD_X	ra, 0(sp)				
+	addi	sp, sp, (XLEN_BYTES*2)
+	ret
+	.size decode_FCMP, .-decode_FCMP
 
 
-.data
+	.data
 
-#endif /* ENABLE_RVF */
+	#endif /* ENABLE_RVF */
 
-#endif /* WITH_CMD_D */
+	#endif /* WITH_CMD_D */

--- a/src/encoding.S
+++ b/src/encoding.S
@@ -1,472 +1,472 @@
-#include "vmon/config.h"
-#include "riscv/riscv-opc.h"
+	#include "vmon/config.h"
+	#include "riscv/riscv-opc.h"
 
-//#ifdef WITH_CMD_D
-#if defined (WITH_CMD_D) || defined (WITH_CMD_A)
-
-
-.global get_register_index_by_name
+	//#ifdef WITH_CMD_D
+	#if defined (WITH_CMD_D) || defined (WITH_CMD_A)
 
 
+	.global get_register_index_by_name
 
-.global encoding_table
-.global int_register_names
-.global float_register_names
-.global string_OP_UNKNOWN
 
-# necessary for c.add/c.jalr/c.ebreak adjustment
-.global string_OP_C_ADD
-.global string_OP_C_JALR
-.global string_OP_C_EBREAK
 
-# in: a0 = start of string ptr to name
-# in: a1 = end of string ptr to name (after last char)
-# out: a2 = index number of register (-1 if error)
+	.global encoding_table
+	.global int_register_names
+	.global float_register_names
+	.global string_OP_UNKNOWN
+
+	# necessary for c.add/c.jalr/c.ebreak adjustment
+	.global string_OP_C_ADD
+	.global string_OP_C_JALR
+	.global string_OP_C_EBREAK
+
+	# in: a0 = start of string ptr to name
+	# in: a1 = end of string ptr to name (after last char)
+	# out: a2 = index number of register (-1 if error)
 get_register_index_by_name:
-/*
+	/*
 find_insn_in_table:
-    la      t0, encoding_table
+	la		t0, encoding_table
 find_insn_in_table_next:
-#if XLEN >= 64
-    lwu     t1, 12(t0)                       # get string ptr from table
-    lwu     a0, 16(t0)                       # get function ptr from table
-#else
-    lw      t1, 12(t0)                       # get string ptr from table
-    lw      a0, 16(t0)                       # get function ptr from table
-#endif
-    beqz    t1, find_insn_in_table_not_found          # table end, no match found
-    # compare strings
-    mv      t2, s0                          # iterate with t2 over input string                         
+	#if XLEN >= 64
+	lwu		t1, 12(t0)						 # get string ptr from table
+	lwu		a0, 16(t0)						 # get function ptr from table
+	#else
+	lw		t1, 12(t0)						 # get string ptr from table
+	lw		a0, 16(t0)						 # get function ptr from table
+	#endif
+	beqz	t1, find_insn_in_table_not_found		  # table end, no match found
+	# compare strings
+	mv		t2, s0							# iterate with t2 over input string							
 find_insn_in_table_cmp_next_byte:
-    beq     t2, s1, find_insn_in_table_done
-    lb      t3, 0(t2)
-    lb      t4, 0(t1)
-    bne     t3, t4, find_insn_in_table_next_entry       # strings not equal
-    beqz    t4, find_insn_in_table_next_entry           # string in table ended
-    addi    t1, t1, 1
-    addi    t2, t2, 1
-    j       find_insn_in_table_cmp_next_byte
+	beq		t2, s1, find_insn_in_table_done
+	lb		t3, 0(t2)
+	lb		t4, 0(t1)
+	bne		t3, t4, find_insn_in_table_next_entry		# strings not equal
+	beqz	t4, find_insn_in_table_next_entry			# string in table ended
+	addi	t1, t1, 1
+	addi	t2, t2, 1
+	j		find_insn_in_table_cmp_next_byte
 find_insn_in_table_next_entry:
-    addi    t0, t0, 20
-    j       find_insn_in_table_next
+	addi	t0, t0, 20
+	j		find_insn_in_table_next
 find_insn_in_table_not_found:
-    mv      a0, zero
+	mv		a0, zero
 find_insn_in_table_done:
-    lw      a1, 4(t0)                       # store MATCH value from table entry in a1
-    ret
+	lw		a1, 4(t0)						# store MATCH value from table entry in a1
+	ret
 
-*/
+	*/
 	
 
 
 
 
-/*	
+	/*	
 	li		a1, -1
 
-    mv      t0, a0                          # iterate with t2 over input string                         
+	mv		t0, a0							# iterate with t2 over input string							
 get_register_index_by_name_cmp_next_byte:
-    beq     t2, s1, find_insn_in_table_done
-    lb      t3, 0(t2)
-    lb      t4, 0(t1)
-    bne     t3, t4, find_insn_in_table_next_entry       # strings not equal
-    beqz    t4, find_insn_in_table_next_entry           # string in table ended
-    addi    t1, t1, 1
-    addi    t2, t2, 1
-    j       find_insn_in_table_cmp_next_byte
+	beq		t2, s1, find_insn_in_table_done
+	lb		t3, 0(t2)
+	lb		t4, 0(t1)
+	bne		t3, t4, find_insn_in_table_next_entry		# strings not equal
+	beqz	t4, find_insn_in_table_next_entry			# string in table ended
+	addi	t1, t1, 1
+	addi	t2, t2, 1
+	j		find_insn_in_table_cmp_next_byte
 get_register_index_by_name_next_entry:
-    addi    t0, t0, 20
-    j       find_insn_in_table_next
+	addi	t0, t0, 20
+	j		find_insn_in_table_next
 get_register_index_by_name_not_found:
-    mv      a0, zero
+	mv		a0, zero
 get_register_index_by_name_done:
-    lw      a1, 4(t0)                       # store MATCH value from table entry in a1
+	lw		a1, 4(t0)						# store MATCH value from table entry in a1
 	ret
-*/
-.size get_register_index_by_name, .-get_register_index_by_name
+	*/
+	.size get_register_index_by_name, .-get_register_index_by_name
 
 
-.data
+	.data
 
-.align 4
+	.align 4
 int_register_names:
-#ifndef ABI_REGISTER_NAMES
-	.string  "x0",  "x1",  "x2",  "x3",  "x4",  "x5",  "x6",  "x7"
-	.string  "x8",  "x9", "x10", "x11", "x12", "x13", "x14", "x15"
+	#ifndef ABI_REGISTER_NAMES
+	.string	 "x0",	"x1",  "x2",  "x3",	 "x4",	"x5",  "x6",  "x7"
+	.string	 "x8",	"x9", "x10", "x11", "x12", "x13", "x14", "x15"
 	.string "x16", "x17", "x18", "x19", "x20", "x21", "x22", "x23"
 	.string "x24", "x25", "x26", "x27", "x28", "x29", "x30", "x31"
-#else
-	.string "zero", "ra",  "sp",  "gp", "tp", "t0", "t1", "t2"
-	.string "fp",   "s1",  "a0",  "a1", "a2", "a3", "a4", "a5"
-	.string "a6",   "a7",  "s2",  "s3", "s4", "s5", "s6", "s7"
-	.string "s8",   "s9", "s10", "s11", "t3", "t4", "t5", "t6"
-#endif
-.size int_register_names, .-int_register_names
-
-
-#ifdef ENABLE_RVF
-	.align 4
-	float_register_names:
-	#ifndef ABI_REGISTER_NAMES
-		.string  "f0",  "f1",  "f2",  "f3",  "f4",  "f5",  "f6",  "f7"
-		.string  "f8",  "f9", "f10", "f11", "f12", "f13", "f14", "f15"
-		.string "f16", "f17", "f18", "f19", "f20", "f21", "f22", "f23"
-		.string "f24", "f25", "f26", "f27", "f28", "f29", "f30", "f31"
 	#else
-		.string "ft0", "ft1",  "ft2",  "ft3", "ft4", "ft5",  "ft6",  "ft7"
-		.string "fs0", "fs1",  "fa0",  "fa1", "fa2", "fa3",  "fa4",  "fa5"
-		.string "fa6", "fa7",  "fs2",  "fs3", "fs4", "fs5",  "fs6",  "fs7"
-		.string "fs8", "fs9", "fs10", "fs11", "ft8", "ft9", "ft10", "ft11"
+	.string "zero", "ra",  "sp",  "gp", "tp", "t0", "t1", "t2"
+	.string "fp",	"s1",  "a0",  "a1", "a2", "a3", "a4", "a5"
+	.string "a6",	"a7",  "s2",  "s3", "s4", "s5", "s6", "s7"
+	.string "s8",	"s9", "s10", "s11", "t3", "t4", "t5", "t6"
+	#endif
+	.size int_register_names, .-int_register_names
+
+
+	#ifdef ENABLE_RVF
+	.align 4
+float_register_names:
+	#ifndef ABI_REGISTER_NAMES
+	.string	 "f0",	"f1",  "f2",  "f3",	 "f4",	"f5",  "f6",  "f7"
+	.string	 "f8",	"f9", "f10", "f11", "f12", "f13", "f14", "f15"
+	.string "f16", "f17", "f18", "f19", "f20", "f21", "f22", "f23"
+	.string "f24", "f25", "f26", "f27", "f28", "f29", "f30", "f31"
+	#else
+	.string "ft0", "ft1",  "ft2",  "ft3", "ft4", "ft5",	 "ft6",	 "ft7"
+	.string "fs0", "fs1",  "fa0",  "fa1", "fa2", "fa3",	 "fa4",	 "fa5"
+	.string "fa6", "fa7",  "fs2",  "fs3", "fs4", "fs5",	 "fs6",	 "fs7"
+	.string "fs8", "fs9", "fs10", "fs11", "ft8", "ft9", "ft10", "ft11"
 	#endif
 	.size float_register_names, .-float_register_names
-#endif /* ENABLE_RVF */
+	#endif /* ENABLE_RVF */
 
-# ---------- opcode strings ----------
+	# ---------- opcode strings ----------
 
-# RV32I
+	# RV32I
 string_opcodes:
-string_OP_LUI:      .string "lui";		
-string_OP_AUIPC:    .string "auipc";		
-string_OP_JAL:      .string "jal";		
-string_OP_JALR:     .string "jalr";		
-string_OP_BEQ:      .string "beq";		
-string_OP_BNE:      .string "bne";		
-string_OP_BLT:      .string "blt";		
-string_OP_BGE:      .string "bge";		
-string_OP_BLTU:     .string "bltu";		
-string_OP_BGEU:     .string "bgeu";		
-string_OP_LB:       .string "lb";		
-string_OP_LH:       .string "lh";		
-string_OP_LW:       .string "lw";		
-string_OP_LBU:      .string "lbu";		
-string_OP_LHU:      .string "lhu";		
-string_OP_SB:       .string "sb";		
-string_OP_SH:       .string "sh";		
-string_OP_SW:       .string "sw";		
-string_OP_ADDI:     .string "addi";		
-string_OP_SLTI:     .string "slti";		
-string_OP_SLTIU:    .string "sltiu";	
-string_OP_XORI:     .string "xori";		
-string_OP_ORI:      .string "ori";		
-string_OP_ANDI:     .string "andi";		
-string_OP_SLLI:     .string "slli";		
-string_OP_SRLI:     .string "srli";		
-string_OP_SRAI:     .string "srai";		
-string_OP_ADD:      .string "add";		
-string_OP_SUB:      .string "sub";		
-string_OP_SLL:      .string "sll";		
-string_OP_SLT:      .string "slt";		
-string_OP_SLTU:     .string "sltu";		
-string_OP_XOR:      .string "xor";		
-string_OP_SRL:      .string "srl";		
-string_OP_SRA:      .string "sra";		
-string_OP_OR:       .string "or";		
-string_OP_AND:      .string "and";		
-string_OP_FENCE:    .string "fence";	
+string_OP_LUI:		.string "lui";		
+string_OP_AUIPC:	.string "auipc";		
+string_OP_JAL:		.string "jal";		
+string_OP_JALR:		.string "jalr";		
+string_OP_BEQ:		.string "beq";		
+string_OP_BNE:		.string "bne";		
+string_OP_BLT:		.string "blt";		
+string_OP_BGE:		.string "bge";		
+string_OP_BLTU:		.string "bltu";		
+string_OP_BGEU:		.string "bgeu";		
+string_OP_LB:		.string "lb";		
+string_OP_LH:		.string "lh";		
+string_OP_LW:		.string "lw";		
+string_OP_LBU:		.string "lbu";		
+string_OP_LHU:		.string "lhu";		
+string_OP_SB:		.string "sb";		
+string_OP_SH:		.string "sh";		
+string_OP_SW:		.string "sw";		
+string_OP_ADDI:		.string "addi";		
+string_OP_SLTI:		.string "slti";		
+string_OP_SLTIU:	.string "sltiu";	
+string_OP_XORI:		.string "xori";		
+string_OP_ORI:		.string "ori";		
+string_OP_ANDI:		.string "andi";		
+string_OP_SLLI:		.string "slli";		
+string_OP_SRLI:		.string "srli";		
+string_OP_SRAI:		.string "srai";		
+string_OP_ADD:		.string "add";		
+string_OP_SUB:		.string "sub";		
+string_OP_SLL:		.string "sll";		
+string_OP_SLT:		.string "slt";		
+string_OP_SLTU:		.string "sltu";		
+string_OP_XOR:		.string "xor";		
+string_OP_SRL:		.string "srl";		
+string_OP_SRA:		.string "sra";		
+string_OP_OR:		.string "or";		
+string_OP_AND:		.string "and";		
+string_OP_FENCE:	.string "fence";	
 string_OP_FENCETSO: .string "fence.tso";	
-string_OP_ECALL:    .string "ecall";	
-string_OP_EBREAK:   .string "ebreak";	
+string_OP_ECALL:	.string "ecall";	
+string_OP_EBREAK:	.string "ebreak";	
 
-# RV64I
-#if XLEN >=64
-	string_OP_LWU:      .string "lwu";		
-	string_OP_LD:       .string "ld";		
-	string_OP_SD:       .string "sd";		
-	string_OP_ADDIW:    .string "addiw";	
-	string_OP_SLLIW:    .string "slliw";	
-	string_OP_SRLIW:    .string "srliw";	
-	string_OP_SRAIW:    .string "sraiw";	
-	string_OP_ADDW:     .string "addw";		
-	string_OP_SUBW:     .string "subw";		
-	string_OP_SLLW:     .string "sllw";		
-	string_OP_SRLW:     .string "srlw";		
-	string_OP_SRAW:     .string "sraw";		
-#endif
+	# RV64I
+	#if XLEN >=64
+string_OP_LWU:		.string "lwu";		
+string_OP_LD:		.string "ld";		
+string_OP_SD:		.string "sd";		
+string_OP_ADDIW:	.string "addiw";	
+string_OP_SLLIW:	.string "slliw";	
+string_OP_SRLIW:	.string "srliw";	
+string_OP_SRAIW:	.string "sraiw";	
+string_OP_ADDW:		.string "addw";		
+string_OP_SUBW:		.string "subw";		
+string_OP_SLLW:		.string "sllw";		
+string_OP_SRLW:		.string "srlw";		
+string_OP_SRAW:		.string "sraw";		
+	#endif
 
-# RVM
-#ifdef ENABLE_RVM
+	# RVM
+	#ifdef ENABLE_RVM
 	# RV32M
-	string_OP_MUL:      .string "mul";			
-	string_OP_MULH:     .string "mulh";			
-	string_OP_MULHU:    .string "mulhu";		
-	string_OP_MULHSU:   .string "mulhsu";	
-	string_OP_DIV:      .string "div";			
-	string_OP_DIVU:     .string "divu";		
-	string_OP_REM:      .string "rem";			
-	string_OP_REMU:     .string "remu";		
+string_OP_MUL:		.string "mul";			
+string_OP_MULH:		.string "mulh";			
+string_OP_MULHU:	.string "mulhu";		
+string_OP_MULHSU:	.string "mulhsu";	
+string_OP_DIV:		.string "div";			
+string_OP_DIVU:		.string "divu";		
+string_OP_REM:		.string "rem";			
+string_OP_REMU:		.string "remu";		
 	# RV64M
 	#if XLEN >=64
-		string_OP_MULW:     .string "mulw";		
-		string_OP_DIVW:     .string "divw";		
-		string_OP_DIVUW:    .string "divuw";	
-		string_OP_REMW:     .string "remw";			
-		string_OP_REMUW:    .string "remuw";	
+string_OP_MULW:		.string "mulw";		
+string_OP_DIVW:		.string "divw";		
+string_OP_DIVUW:	.string "divuw";	
+string_OP_REMW:		.string "remw";			
+string_OP_REMUW:	.string "remuw";	
 	#endif
-#endif /* ENABLE_RVM */
+	#endif /* ENABLE_RVM */
 
-# RVA
-#ifdef ENABLE_RVA
+	# RVA
+	#ifdef ENABLE_RVA
 	# RV32A
-	string_OP_LRW:		.string "lr.w";	
-	string_OP_SCW:		.string "sc.w";	
-	string_OP_AMOSWAPW:	.string "amoswap.w";	
-	string_OP_AMOADDW:	.string "amoadd.w";	
-	string_OP_AMOANDW:	.string "amoand.w";	
-	string_OP_AMOORW:	.string "amoor.w";	
-	string_OP_AMOXORW:	.string "amoxor.w";	
-	string_OP_AMOMAXW:	.string "amomax.w";	
-	string_OP_AMOMINW:	.string "amomin.w";	
-	string_OP_AMOMAXUW:	.string "amomaxu.w";	
-	string_OP_AMOMINUW:	.string "amominu.w";	
+string_OP_LRW:		.string "lr.w";	
+string_OP_SCW:		.string "sc.w";	
+string_OP_AMOSWAPW:	.string "amoswap.w";	
+string_OP_AMOADDW:	.string "amoadd.w";	
+string_OP_AMOANDW:	.string "amoand.w";	
+string_OP_AMOORW:	.string "amoor.w";	
+string_OP_AMOXORW:	.string "amoxor.w";	
+string_OP_AMOMAXW:	.string "amomax.w";	
+string_OP_AMOMINW:	.string "amomin.w";	
+string_OP_AMOMAXUW:	.string "amomaxu.w";	
+string_OP_AMOMINUW:	.string "amominu.w";	
 	# RV64A
 	#if XLEN >= 64
-		string_OP_LRD:		.string "lr.d";	
-		string_OP_SCD:		.string "sc.d";	
-		string_OP_AMOSWAPD:	.string "amoswap.d";	
-		string_OP_AMOADDD:	.string "amoadd.d";	
-		string_OP_AMOANDD:	.string "amoand.d";	
-		string_OP_AMOORD:	.string "amoor.d";	
-		string_OP_AMOXORD:	.string "amoxor.d";	
-		string_OP_AMOMAXD:	.string "amomax.d";	
-		string_OP_AMOMIND:	.string "amomin.d";	
-		string_OP_AMOMAXUD:	.string "amomaxu.d";	
-		string_OP_AMOMINUD:	.string "amominu.d";	
+string_OP_LRD:		.string "lr.d";	
+string_OP_SCD:		.string "sc.d";	
+string_OP_AMOSWAPD:	.string "amoswap.d";	
+string_OP_AMOADDD:	.string "amoadd.d";	
+string_OP_AMOANDD:	.string "amoand.d";	
+string_OP_AMOORD:	.string "amoor.d";	
+string_OP_AMOXORD:	.string "amoxor.d";	
+string_OP_AMOMAXD:	.string "amomax.d";	
+string_OP_AMOMIND:	.string "amomin.d";	
+string_OP_AMOMAXUD:	.string "amomaxu.d";	
+string_OP_AMOMINUD:	.string "amominu.d";	
 	#endif
-#endif /* ENABLE_RVA */
+	#endif /* ENABLE_RVA */
 
-# RVF / RVD / RVQ
-#ifdef ENABLE_RVF
-	string_OP_FLW:  		.string "flw";
-	string_OP_FSW:  		.string "fsw";
-	string_OP_FMADD_S:  	.string "fmadd.s";
-	string_OP_FMSUB_S:  	.string "fmsub.s";
-	string_OP_FNMADD_S:		.string "fnmadd.s";
-	string_OP_FNMSUB_S:		.string "fnmsub.s";
-	string_OP_FADD_S:		.string "fadd.s";
-	string_OP_FSUB_S:		.string "fsub.s";
-	string_OP_FMUL_S:		.string "fmul.s";
-	string_OP_FDIV_S:		.string "fdiv.s";
-	string_OP_FSQRT_S:		.string "fsqrt.s";
-	string_OP_FSGNJ_S:		.string "fsgnj.s";
-	string_OP_FSGNJN_S:		.string "fsgnjn.s";
-	string_OP_FSGNJX_S:		.string "fsgnjx.s";
-	string_OP_FMIN_S:		.string "fmin.s";
-	string_OP_FMAX_S:		.string "fmax.s";
-	string_OP_FCVT_S_W:		.string "fcvt.s.w";
-	string_OP_FCVT_S_WU:	.string "fcvt.s.wu";
-	string_OP_FCVT_W_S:		.string "fcvt.w.s";
-	string_OP_FCVT_WU_S:	.string "fcvt.wu.s";
-	string_OP_FMV_X_S:		.string "fmv.x.w";
-	string_OP_FMV_S_X:		.string "fmv.w.x";
-	string_OP_FEQ_S:		.string "feq.s";
-	string_OP_FLT_S:		.string "flt.s";
-	string_OP_FLE_S:		.string "fle.s";
-	string_OP_FCLASS_S:		.string "fclass.s";
-	#ifdef ENABLE_RVD
-		string_OP_FLD:  		.string "fld";
-		string_OP_FSD:  		.string "fsd";
-		string_OP_FMADD_D:  	.string "fmadd.d";
-		string_OP_FMSUB_D:  	.string "fmsub.d";
-		string_OP_FNMADD_D:		.string "fnmadd.d";
-		string_OP_FNMSUB_D:		.string "fnmsub.d";
-		string_OP_FADD_D:		.string "fadd.d";
-		string_OP_FSUB_D:		.string "fsub.d";
-		string_OP_FMUL_D:		.string "fmul.d";
-		string_OP_FDIV_D:		.string "fdiv.d";
-		string_OP_FSQRT_D:		.string "fsqrt.d";
-		string_OP_FSGNJ_D:		.string "fsgnj.d";
-		string_OP_FSGNJN_D:		.string "fsgnjn.d";
-		string_OP_FSGNJX_D:		.string "fsgnjx.d";
-		string_OP_FMIN_D:		.string "fmin.d";
-		string_OP_FMAX_D:		.string "fmax.d";
-		string_OP_FCVT_D_W:		.string "fcvt.d.w";
-		string_OP_FCVT_D_WU:	.string "fcvt.d.wu";
-		string_OP_FCVT_W_D:		.string "fcvt.w.d";
-		string_OP_FCVT_WU_D:	.string "fcvt.wu.d";
-		string_OP_FMV_X_D:		.string "fmv.x.d";
-		string_OP_FMV_D_X:		.string "fmv.d.x";
-		string_OP_FEQ_D:		.string "feq.d";
-		string_OP_FLT_D:		.string "flt.d";
-		string_OP_FLE_D:		.string "fle.d";
-		string_OP_FCLASS_D:		.string "fclass.d";
-		#ifdef ENABLE_RVQ
-			string_OP_FLQ:  		.string "flq";
-			string_OP_FSQ:  		.string "fsq";
-			string_OP_FMADD_Q:  	.string "fmadd.q";
-			string_OP_FMSUB_Q:  	.string "fmsub.q";
-			string_OP_FNMADD_Q:		.string "fnmadd.q";
-			string_OP_FNMSUB_Q:		.string "fnmsub.q";		
-			string_OP_FADD_Q:		.string "fadd.q";
-			string_OP_FSUB_Q:		.string "fsub.q";
-			string_OP_FMUL_Q:		.string "fmul.q";
-			string_OP_FDIV_Q:		.string "fdiv.q";
-			string_OP_FSQRT_Q:		.string "fsqrt.q";
-			string_OP_FSGNJ_Q:		.string "fsgnj.q";
-			string_OP_FSGNJN_Q:		.string "fsgnjn.q";
-			string_OP_FSGNJX_Q:		.string "fsgnjx.q";
-			string_OP_FMIN_Q:		.string "fmin.q";
-			string_OP_FMAX_Q:		.string "fmax.q";
-			string_OP_FCVT_Q_W:		.string "fcvt.q.w";
-			string_OP_FCVT_Q_WU:	.string "fcvt.q.wu";
-			string_OP_FCVT_W_Q:		.string "fcvt.w.q";
-			string_OP_FCVT_WU_Q:	.string "fcvt.wu.q";
-			#if XLEN >=128
-				string_OP_FMV_X_Q:		.string "fmv.x.q";
-				string_OP_FMV_Q_X:		.string "fmv.q.x";
-			#endif
-			string_OP_FEQ_Q:		.string "feq.q";
-			string_OP_FLT_Q:		.string "flt.q";
-			string_OP_FLE_Q:		.string "fle.q";
-			string_OP_FCLASS_Q:		.string "fclass.q";
-		#endif
-	#endif /* ENABLE_RVD */
-#endif /* ENABLE_RVF */
-
-# Zifencei
-#ifdef ENABLE_RVZifencei
-	string_OP_FENCE_I:  .string "fence.i";	#
-#endif /* ENABLE_RVZifencei */
-
-# Zicsr
-#ifdef ENABLE_RVZicsr
-	string_OP_CSRRW:    .string "csrrw";		
-	string_OP_CSRRS:    .string "csrrs";	
-	string_OP_CSRRC:    .string "csrrc";	
-	string_OP_CSRRWI:   .string "csrrwi";	
-	string_OP_CSRRSI:   .string "csrrsi";	
-	string_OP_CSRRCI:	.string "csrrci";	
-#endif /* ENABLE_RVZicsr */
-
-# RVC
-#ifdef ENABLE_RVC
-	string_OP_C_LW:			.string "c.lw";
-	string_OP_C_SW:			.string "c.sw";
-	string_OP_C_ADDI:		.string "c.addi";
-	string_OP_C_JAL:		.string "c.jal";
-	string_OP_C_LI:			.string "c.li";
-	string_OP_C_LUI:		.string "c.lui";
-	string_OP_C_SRLI:		.string "c.srli";
-	string_OP_C_SRLI64:		.string "c.srli64";
-	string_OP_C_SRAI:		.string "c.srai";
-	string_OP_C_SRAI64:		.string "c.srai64";
-	string_OP_C_ANDI:		.string "c.andi";
-	string_OP_C_SUB:		.string "c.sub";
-	string_OP_C_XOR:		.string "c.xor";
-	string_OP_C_OR:			.string "c.or";
-	string_OP_C_AND:		.string "c.and";
-	string_OP_C_SUBW:		.string "c.subw";
-	string_OP_C_ADDW:		.string "c.addw";
-	string_OP_C_J:			.string "c.j";
-	string_OP_C_BEQZ:		.string "c.beqz";
-	string_OP_C_BNEZ:		.string "c.bnez";
-	string_OP_C_SLLI:		.string "c.slli";
-	string_OP_C_SLLI64:		.string "c.slli64";
-	string_OP_C_LWSP:		.string "c.lwsp";
-	string_OP_C_MV:			.string "c.mv";
-	string_OP_C_ADD:		.string "c.add";
-	string_OP_C_SWSP:		.string "c.swsp";
-	string_OP_C_NOP:		.string "c.nop";
-	string_OP_C_ADDI16SP:	.string "c.addi16sp";
-	string_OP_C_JR:			.string "c.jr";
-	string_OP_C_JALR:		.string "c.jalr";
-	string_OP_C_EBREAK:		.string "c.ebreak";
-	string_OP_C_LD:			.string "c.ld";
-	string_OP_C_SD:			.string "c.sd";
-	string_OP_C_ADDIW:		.string "c.addiw";
-	string_OP_C_LDSP:		.string "c.ldsp";
-	string_OP_C_SDSP:		.string "c.sdsp";
+	# RVF / RVD / RVQ
 	#ifdef ENABLE_RVF
-		string_OP_C_FLD:		.string "c.fld";
-		string_OP_C_FSD:		.string "c.fsd";
-		string_OP_C_FLW:		.string "c.flw";
-		string_OP_C_FSW:		.string "c.fsw";
-		string_OP_C_FLDSP:		.string "c.fldsp";
-		string_OP_C_FLWSP:		.string "c.flwsp";
-		string_OP_C_FSDSP:		.string "c.fsdsp";
-		string_OP_C_FSWSP:		.string "c.fswsp";
+string_OP_FLW:			.string "flw";
+string_OP_FSW:			.string "fsw";
+string_OP_FMADD_S:		.string "fmadd.s";
+string_OP_FMSUB_S:		.string "fmsub.s";
+string_OP_FNMADD_S:		.string "fnmadd.s";
+string_OP_FNMSUB_S:		.string "fnmsub.s";
+string_OP_FADD_S:		.string "fadd.s";
+string_OP_FSUB_S:		.string "fsub.s";
+string_OP_FMUL_S:		.string "fmul.s";
+string_OP_FDIV_S:		.string "fdiv.s";
+string_OP_FSQRT_S:		.string "fsqrt.s";
+string_OP_FSGNJ_S:		.string "fsgnj.s";
+string_OP_FSGNJN_S:		.string "fsgnjn.s";
+string_OP_FSGNJX_S:		.string "fsgnjx.s";
+string_OP_FMIN_S:		.string "fmin.s";
+string_OP_FMAX_S:		.string "fmax.s";
+string_OP_FCVT_S_W:		.string "fcvt.s.w";
+string_OP_FCVT_S_WU:	.string "fcvt.s.wu";
+string_OP_FCVT_W_S:		.string "fcvt.w.s";
+string_OP_FCVT_WU_S:	.string "fcvt.wu.s";
+string_OP_FMV_X_S:		.string "fmv.x.w";
+string_OP_FMV_S_X:		.string "fmv.w.x";
+string_OP_FEQ_S:		.string "feq.s";
+string_OP_FLT_S:		.string "flt.s";
+string_OP_FLE_S:		.string "fle.s";
+string_OP_FCLASS_S:		.string "fclass.s";
+	#ifdef ENABLE_RVD
+string_OP_FLD:			.string "fld";
+string_OP_FSD:			.string "fsd";
+string_OP_FMADD_D:		.string "fmadd.d";
+string_OP_FMSUB_D:		.string "fmsub.d";
+string_OP_FNMADD_D:		.string "fnmadd.d";
+string_OP_FNMSUB_D:		.string "fnmsub.d";
+string_OP_FADD_D:		.string "fadd.d";
+string_OP_FSUB_D:		.string "fsub.d";
+string_OP_FMUL_D:		.string "fmul.d";
+string_OP_FDIV_D:		.string "fdiv.d";
+string_OP_FSQRT_D:		.string "fsqrt.d";
+string_OP_FSGNJ_D:		.string "fsgnj.d";
+string_OP_FSGNJN_D:		.string "fsgnjn.d";
+string_OP_FSGNJX_D:		.string "fsgnjx.d";
+string_OP_FMIN_D:		.string "fmin.d";
+string_OP_FMAX_D:		.string "fmax.d";
+string_OP_FCVT_D_W:		.string "fcvt.d.w";
+string_OP_FCVT_D_WU:	.string "fcvt.d.wu";
+string_OP_FCVT_W_D:		.string "fcvt.w.d";
+string_OP_FCVT_WU_D:	.string "fcvt.wu.d";
+string_OP_FMV_X_D:		.string "fmv.x.d";
+string_OP_FMV_D_X:		.string "fmv.d.x";
+string_OP_FEQ_D:		.string "feq.d";
+string_OP_FLT_D:		.string "flt.d";
+string_OP_FLE_D:		.string "fle.d";
+string_OP_FCLASS_D:		.string "fclass.d";
+	#ifdef ENABLE_RVQ
+string_OP_FLQ:			.string "flq";
+string_OP_FSQ:			.string "fsq";
+string_OP_FMADD_Q:		.string "fmadd.q";
+string_OP_FMSUB_Q:		.string "fmsub.q";
+string_OP_FNMADD_Q:		.string "fnmadd.q";
+string_OP_FNMSUB_Q:		.string "fnmsub.q";		
+string_OP_FADD_Q:		.string "fadd.q";
+string_OP_FSUB_Q:		.string "fsub.q";
+string_OP_FMUL_Q:		.string "fmul.q";
+string_OP_FDIV_Q:		.string "fdiv.q";
+string_OP_FSQRT_Q:		.string "fsqrt.q";
+string_OP_FSGNJ_Q:		.string "fsgnj.q";
+string_OP_FSGNJN_Q:		.string "fsgnjn.q";
+string_OP_FSGNJX_Q:		.string "fsgnjx.q";
+string_OP_FMIN_Q:		.string "fmin.q";
+string_OP_FMAX_Q:		.string "fmax.q";
+string_OP_FCVT_Q_W:		.string "fcvt.q.w";
+string_OP_FCVT_Q_WU:	.string "fcvt.q.wu";
+string_OP_FCVT_W_Q:		.string "fcvt.w.q";
+string_OP_FCVT_WU_Q:	.string "fcvt.wu.q";
+	#if XLEN >=128
+string_OP_FMV_X_Q:		.string "fmv.x.q";
+string_OP_FMV_Q_X:		.string "fmv.q.x";
+	#endif
+string_OP_FEQ_Q:		.string "feq.q";
+string_OP_FLT_Q:		.string "flt.q";
+string_OP_FLE_Q:		.string "fle.q";
+string_OP_FCLASS_Q:		.string "fclass.q";
+	#endif
+	#endif /* ENABLE_RVD */
 	#endif /* ENABLE_RVF */
-#endif /* ENABLE_RVC */
 
-# Pseudo
-#ifdef ENABLE_PSEUDO
-	string_OP_RET:		.string "ret";	
-	string_OP_NOP:		.string "nop";	
-#endif /* ENABLE_PSEUDO */
+	# Zifencei
+	#ifdef ENABLE_RVZifencei
+string_OP_FENCE_I:	.string "fence.i";	#
+	#endif /* ENABLE_RVZifencei */
 
-# Pseudo
-#ifdef ENABLE_RVPRIV
-	string_OP_WFI:			.string "wfi";	
-	string_OP_MRET:			.string "mret";	
-	string_OP_SRET:			.string "sret";	
-	string_OP_SFENCE_VM:	.string "sfence.vm";	
-	string_OP_SFENCE_VMA:	.string "sfence.vma";	
-#endif /* ENABLE_PSEUDO */
+	# Zicsr
+	#ifdef ENABLE_RVZicsr
+string_OP_CSRRW:	.string "csrrw";		
+string_OP_CSRRS:	.string "csrrs";	
+string_OP_CSRRC:	.string "csrrc";	
+string_OP_CSRRWI:	.string "csrrwi";	
+string_OP_CSRRSI:	.string "csrrsi";	
+string_OP_CSRRCI:	.string "csrrci";	
+	#endif /* ENABLE_RVZicsr */
 
-.size string_opcodes, .-string_opcodes
+	# RVC
+	#ifdef ENABLE_RVC
+string_OP_C_LW:			.string "c.lw";
+string_OP_C_SW:			.string "c.sw";
+string_OP_C_ADDI:		.string "c.addi";
+string_OP_C_JAL:		.string "c.jal";
+string_OP_C_LI:			.string "c.li";
+string_OP_C_LUI:		.string "c.lui";
+string_OP_C_SRLI:		.string "c.srli";
+string_OP_C_SRLI64:		.string "c.srli64";
+string_OP_C_SRAI:		.string "c.srai";
+string_OP_C_SRAI64:		.string "c.srai64";
+string_OP_C_ANDI:		.string "c.andi";
+string_OP_C_SUB:		.string "c.sub";
+string_OP_C_XOR:		.string "c.xor";
+string_OP_C_OR:			.string "c.or";
+string_OP_C_AND:		.string "c.and";
+string_OP_C_SUBW:		.string "c.subw";
+string_OP_C_ADDW:		.string "c.addw";
+string_OP_C_J:			.string "c.j";
+string_OP_C_BEQZ:		.string "c.beqz";
+string_OP_C_BNEZ:		.string "c.bnez";
+string_OP_C_SLLI:		.string "c.slli";
+string_OP_C_SLLI64:		.string "c.slli64";
+string_OP_C_LWSP:		.string "c.lwsp";
+string_OP_C_MV:			.string "c.mv";
+string_OP_C_ADD:		.string "c.add";
+string_OP_C_SWSP:		.string "c.swsp";
+string_OP_C_NOP:		.string "c.nop";
+string_OP_C_ADDI16SP:	.string "c.addi16sp";
+string_OP_C_JR:			.string "c.jr";
+string_OP_C_JALR:		.string "c.jalr";
+string_OP_C_EBREAK:		.string "c.ebreak";
+string_OP_C_LD:			.string "c.ld";
+string_OP_C_SD:			.string "c.sd";
+string_OP_C_ADDIW:		.string "c.addiw";
+string_OP_C_LDSP:		.string "c.ldsp";
+string_OP_C_SDSP:		.string "c.sdsp";
+	#ifdef ENABLE_RVF
+string_OP_C_FLD:		.string "c.fld";
+string_OP_C_FSD:		.string "c.fsd";
+string_OP_C_FLW:		.string "c.flw";
+string_OP_C_FSW:		.string "c.fsw";
+string_OP_C_FLDSP:		.string "c.fldsp";
+string_OP_C_FLWSP:		.string "c.flwsp";
+string_OP_C_FSDSP:		.string "c.fsdsp";
+string_OP_C_FSWSP:		.string "c.fswsp";
+	#endif /* ENABLE_RVF */
+	#endif /* ENABLE_RVC */
+
+	# Pseudo
+	#ifdef ENABLE_PSEUDO
+string_OP_RET:		.string "ret";	
+string_OP_NOP:		.string "nop";	
+	#endif /* ENABLE_PSEUDO */
+
+	# Pseudo
+	#ifdef ENABLE_RVPRIV
+string_OP_WFI:			.string "wfi";	
+string_OP_MRET:			.string "mret";	
+string_OP_SRET:			.string "sret";	
+string_OP_SFENCE_VM:	.string "sfence.vm";	
+string_OP_SFENCE_VMA:	.string "sfence.vma";	
+	#endif /* ENABLE_PSEUDO */
+
+	.size string_opcodes, .-string_opcodes
 
 
-# ---------- set up an encoding table  ----------
+	# ---------- set up an encoding table  ----------
 
 
-.align 4
+	.align 4
 
 encoding_table:
-# format: MASK, MATCH, decode function ptr, opcode string
+	# format: MASK, MATCH, decode function ptr, opcode string
 
-# pseudo opcodes
-# order is important, these have to be at the beginning of the table
-#ifdef ENABLE_PSEUDO
+	# pseudo opcodes
+	# order is important, these have to be at the beginning of the table
+	#ifdef ENABLE_PSEUDO
 	.word 0xffffffff, 0x00008067, decode_EMPTY, string_OP_RET, assemble_VOID
 	.word 0xffffffff, 0x00000013, decode_EMPTY, string_OP_NOP, assemble_VOID
 	#ifdef ENABLE_RVC
-		.word 0x0000ffff, 0x0001, decode_EMPTY, string_OP_C_NOP, assemble_VOID
+	.word 0x0000ffff, 0x0001, decode_EMPTY, string_OP_C_NOP, assemble_VOID
 	#endif /* ENABLE_RVC */
-#endif /* ENABLE_PSEUDO */
+	#endif /* ENABLE_PSEUDO */
 
-# RV32I
-.word MASK_ADD, MATCH_ADD, decode_R_type, string_OP_ADD, assemble_DUMMY
-.word MASK_SUB, MATCH_SUB, decode_R_type, string_OP_SUB, assemble_DUMMY
-.word MASK_XOR, MATCH_XOR, decode_R_type, string_OP_XOR, assemble_DUMMY
-.word MASK_OR, MATCH_OR, decode_R_type, string_OP_OR, assemble_DUMMY
-.word MASK_AND, MATCH_AND, decode_R_type, string_OP_AND, assemble_DUMMY
-.word MASK_SLL, MATCH_SLL, decode_R_type, string_OP_SLL, assemble_DUMMY
-.word MASK_SRL, MATCH_SRL, decode_R_type, string_OP_SRL, assemble_DUMMY
-.word MASK_SRA, MATCH_SRA, decode_R_type, string_OP_SRA, assemble_DUMMY
-.word MASK_SLT, MATCH_SLT, decode_R_type, string_OP_SLT, assemble_DUMMY
-.word MASK_SLTU, MATCH_SLTU, decode_R_type, string_OP_SLTU, assemble_DUMMY
-.word MASK_ADDI, MATCH_ADDI, decode_I_type, string_OP_ADDI, assemble_DUMMY
-.word MASK_XORI, MATCH_XORI, decode_I_type, string_OP_XORI, assemble_DUMMY
-.word MASK_ORI, MATCH_ORI, decode_I_type, string_OP_ORI, assemble_DUMMY
-.word MASK_ANDI, MATCH_ANDI, decode_I_type, string_OP_ANDI, assemble_DUMMY
-.word MASK_SLLI, MATCH_SLLI, decode_I_type_SHIFT, string_OP_SLLI, assemble_DUMMY
-.word MASK_SRLI, MATCH_SRLI, decode_I_type_SHIFT, string_OP_SRLI, assemble_DUMMY
-.word MASK_SRAI, MATCH_SRAI, decode_I_type_SHIFT, string_OP_SRAI, assemble_DUMMY
-.word MASK_SLTI, MATCH_SLTI, decode_I_type, string_OP_SLTI, assemble_DUMMY
-.word MASK_SLTIU, MATCH_SLTIU, decode_I_type, string_OP_SLTIU, assemble_DUMMY
-.word MASK_LB, MATCH_LB, decode_I_type_LOAD, string_OP_LB, assemble_DUMMY
-.word MASK_LH, MATCH_LH, decode_I_type_LOAD, string_OP_LH, assemble_DUMMY
-.word MASK_LW, MATCH_LW, decode_I_type_LOAD, string_OP_LW, assemble_DUMMY
-.word MASK_LBU, MATCH_LBU, decode_I_type_LOAD, string_OP_LBU, assemble_DUMMY
-.word MASK_LHU, MATCH_LHU, decode_I_type_LOAD, string_OP_LHU, assemble_DUMMY
-.word MASK_SB, MATCH_SB, decode_S_type, string_OP_SB, assemble_DUMMY
-.word MASK_SH, MATCH_SH, decode_S_type, string_OP_SH, assemble_DUMMY
-.word MASK_SW, MATCH_SW, decode_S_type, string_OP_SW, assemble_DUMMY
-.word MASK_BEQ, MATCH_BEQ, decode_B_type, string_OP_BEQ, assemble_BRANCH
-.word MASK_BNE, MATCH_BNE, decode_B_type, string_OP_BNE, assemble_BRANCH
-.word MASK_BLT, MATCH_BLT, decode_B_type, string_OP_BLT, assemble_BRANCH
-.word MASK_BGE, MATCH_BGE, decode_B_type, string_OP_BGE, assemble_BRANCH
-.word MASK_BLTU, MATCH_BLTU, decode_B_type, string_OP_BLTU, assemble_BRANCH
-.word MASK_BGEU, MATCH_BGEU, decode_B_type, string_OP_BGEU, assemble_BRANCH
-.word MASK_JAL, MATCH_JAL, decode_JAL, string_OP_JAL, assemble_DUMMY
-.word MASK_JALR, MATCH_JALR, decode_I_type_LOAD, string_OP_JALR, assemble_DUMMY
-.word MASK_LUI, MATCH_LUI, decode_U_type, string_OP_LUI, assemble_DUMMY
-.word MASK_AUIPC, MATCH_AUIPC, decode_U_type, string_OP_AUIPC, assemble_DUMMY
-.word MASK_ECALL, MATCH_ECALL, decode_ECALL, string_OP_ECALL, assemble_VOID
-.word MASK_EBREAK, MATCH_EBREAK, decode_EBREAK, string_OP_EBREAK, assemble_VOID
-.word MASK_FENCETSO, MATCH_FENCETSO, decode_FENCE_TSO, string_OP_FENCETSO, assemble_VOID
-.word MASK_FENCE, MATCH_FENCE, decode_FENCE, string_OP_FENCE, assemble_DUMMY
-# RV64I
-#if XLEN >= 64
+	# RV32I
+	.word MASK_ADD, MATCH_ADD, decode_R_type, string_OP_ADD, assemble_DUMMY
+	.word MASK_SUB, MATCH_SUB, decode_R_type, string_OP_SUB, assemble_DUMMY
+	.word MASK_XOR, MATCH_XOR, decode_R_type, string_OP_XOR, assemble_DUMMY
+	.word MASK_OR, MATCH_OR, decode_R_type, string_OP_OR, assemble_DUMMY
+	.word MASK_AND, MATCH_AND, decode_R_type, string_OP_AND, assemble_DUMMY
+	.word MASK_SLL, MATCH_SLL, decode_R_type, string_OP_SLL, assemble_DUMMY
+	.word MASK_SRL, MATCH_SRL, decode_R_type, string_OP_SRL, assemble_DUMMY
+	.word MASK_SRA, MATCH_SRA, decode_R_type, string_OP_SRA, assemble_DUMMY
+	.word MASK_SLT, MATCH_SLT, decode_R_type, string_OP_SLT, assemble_DUMMY
+	.word MASK_SLTU, MATCH_SLTU, decode_R_type, string_OP_SLTU, assemble_DUMMY
+	.word MASK_ADDI, MATCH_ADDI, decode_I_type, string_OP_ADDI, assemble_DUMMY
+	.word MASK_XORI, MATCH_XORI, decode_I_type, string_OP_XORI, assemble_DUMMY
+	.word MASK_ORI, MATCH_ORI, decode_I_type, string_OP_ORI, assemble_DUMMY
+	.word MASK_ANDI, MATCH_ANDI, decode_I_type, string_OP_ANDI, assemble_DUMMY
+	.word MASK_SLLI, MATCH_SLLI, decode_I_type_SHIFT, string_OP_SLLI, assemble_DUMMY
+	.word MASK_SRLI, MATCH_SRLI, decode_I_type_SHIFT, string_OP_SRLI, assemble_DUMMY
+	.word MASK_SRAI, MATCH_SRAI, decode_I_type_SHIFT, string_OP_SRAI, assemble_DUMMY
+	.word MASK_SLTI, MATCH_SLTI, decode_I_type, string_OP_SLTI, assemble_DUMMY
+	.word MASK_SLTIU, MATCH_SLTIU, decode_I_type, string_OP_SLTIU, assemble_DUMMY
+	.word MASK_LB, MATCH_LB, decode_I_type_LOAD, string_OP_LB, assemble_DUMMY
+	.word MASK_LH, MATCH_LH, decode_I_type_LOAD, string_OP_LH, assemble_DUMMY
+	.word MASK_LW, MATCH_LW, decode_I_type_LOAD, string_OP_LW, assemble_DUMMY
+	.word MASK_LBU, MATCH_LBU, decode_I_type_LOAD, string_OP_LBU, assemble_DUMMY
+	.word MASK_LHU, MATCH_LHU, decode_I_type_LOAD, string_OP_LHU, assemble_DUMMY
+	.word MASK_SB, MATCH_SB, decode_S_type, string_OP_SB, assemble_DUMMY
+	.word MASK_SH, MATCH_SH, decode_S_type, string_OP_SH, assemble_DUMMY
+	.word MASK_SW, MATCH_SW, decode_S_type, string_OP_SW, assemble_DUMMY
+	.word MASK_BEQ, MATCH_BEQ, decode_B_type, string_OP_BEQ, assemble_BRANCH
+	.word MASK_BNE, MATCH_BNE, decode_B_type, string_OP_BNE, assemble_BRANCH
+	.word MASK_BLT, MATCH_BLT, decode_B_type, string_OP_BLT, assemble_BRANCH
+	.word MASK_BGE, MATCH_BGE, decode_B_type, string_OP_BGE, assemble_BRANCH
+	.word MASK_BLTU, MATCH_BLTU, decode_B_type, string_OP_BLTU, assemble_BRANCH
+	.word MASK_BGEU, MATCH_BGEU, decode_B_type, string_OP_BGEU, assemble_BRANCH
+	.word MASK_JAL, MATCH_JAL, decode_JAL, string_OP_JAL, assemble_DUMMY
+	.word MASK_JALR, MATCH_JALR, decode_I_type_LOAD, string_OP_JALR, assemble_DUMMY
+	.word MASK_LUI, MATCH_LUI, decode_U_type, string_OP_LUI, assemble_DUMMY
+	.word MASK_AUIPC, MATCH_AUIPC, decode_U_type, string_OP_AUIPC, assemble_DUMMY
+	.word MASK_ECALL, MATCH_ECALL, decode_ECALL, string_OP_ECALL, assemble_VOID
+	.word MASK_EBREAK, MATCH_EBREAK, decode_EBREAK, string_OP_EBREAK, assemble_VOID
+	.word MASK_FENCETSO, MATCH_FENCETSO, decode_FENCE_TSO, string_OP_FENCETSO, assemble_VOID
+	.word MASK_FENCE, MATCH_FENCE, decode_FENCE, string_OP_FENCE, assemble_DUMMY
+	# RV64I
+	#if XLEN >= 64
 	.word MASK_ADDIW, MATCH_ADDIW, decode_I_type, string_OP_ADDIW, assemble_DUMMY
 	.word MASK_SLLIW, MATCH_SLLIW, decode_I_type_SHIFT, string_OP_SLLIW, assemble_DUMMY
 	.word MASK_SRLIW, MATCH_SRLIW, decode_I_type_SHIFT, string_OP_SRLIW, assemble_DUMMY
@@ -479,10 +479,10 @@ encoding_table:
 	.word MASK_LD, MATCH_LD, decode_I_type_LOAD, string_OP_LD, assemble_DUMMY
 	.word MASK_LWU, MATCH_LWU, decode_I_type_LOAD, string_OP_LWU, assemble_DUMMY
 	.word MASK_SD, MATCH_SD, decode_S_type, string_OP_SD, assemble_DUMMY
-#endif
+	#endif
 
-# RVM
-#ifdef ENABLE_RVM
+	# RVM
+	#ifdef ENABLE_RVM
 	# RV32M
 	.word MASK_MUL, MATCH_MUL, decode_R_type, string_OP_MUL, assemble_DUMMY
 	.word MASK_MULH, MATCH_MULH, decode_R_type, string_OP_MULH, assemble_DUMMY
@@ -494,16 +494,16 @@ encoding_table:
 	.word MASK_REMU, MATCH_REMU, decode_R_type, string_OP_REMU, assemble_DUMMY
 	# RV64M
 	#if XLEN >= 64
-		.word MASK_MULW, MATCH_MULW, decode_R_type, string_OP_MULW, assemble_DUMMY
-		.word MASK_DIVW, MATCH_DIVW, decode_R_type, string_OP_DIVW, assemble_DUMMY
-		.word MASK_DIVUW, MATCH_DIVUW, decode_R_type, string_OP_DIVUW, assemble_DUMMY
-		.word MASK_REMW, MATCH_REMW, decode_R_type, string_OP_REMW, assemble_DUMMY
-		.word MASK_REMUW, MATCH_REMUW, decode_R_type, string_OP_REMUW, assemble_DUMMY
+	.word MASK_MULW, MATCH_MULW, decode_R_type, string_OP_MULW, assemble_DUMMY
+	.word MASK_DIVW, MATCH_DIVW, decode_R_type, string_OP_DIVW, assemble_DUMMY
+	.word MASK_DIVUW, MATCH_DIVUW, decode_R_type, string_OP_DIVUW, assemble_DUMMY
+	.word MASK_REMW, MATCH_REMW, decode_R_type, string_OP_REMW, assemble_DUMMY
+	.word MASK_REMUW, MATCH_REMUW, decode_R_type, string_OP_REMUW, assemble_DUMMY
 	#endif
-#endif /* ENABLE_RVM */
+	#endif /* ENABLE_RVM */
 
-# RVA
-#ifdef ENABLE_RVA
+	# RVA
+	#ifdef ENABLE_RVA
 	# RV32A
 	.word MASK_LR_W, MATCH_LR_W, decode_LRSC, string_OP_LRW, assemble_DUMMY
 	.word MASK_SC_W, MATCH_SC_W, decode_LRSC, string_OP_SCW, assemble_DUMMY
@@ -518,23 +518,23 @@ encoding_table:
 	.word MASK_AMOMINU_W, MATCH_AMOMINU_W, decode_AMO, string_OP_AMOMINUW, assemble_DUMMY
 	# RV64A
 	#if XLEN >= 64
-		.word MASK_LR_D, MATCH_LR_D, decode_LRSC, string_OP_LRD, assemble_DUMMY
-		.word MASK_SC_D, MATCH_SC_D, decode_LRSC, string_OP_SCD, assemble_DUMMY
-		.word MASK_AMOSWAP_D, MATCH_AMOSWAP_D, decode_AMO, string_OP_AMOSWAPD, assemble_DUMMY
-		.word MASK_AMOADD_D, MATCH_AMOADD_D, decode_AMO, string_OP_AMOADDD, assemble_DUMMY
-		.word MASK_AMOAND_D, MATCH_AMOAND_D, decode_AMO, string_OP_AMOANDD, assemble_DUMMY
-		.word MASK_AMOOR_D, MATCH_AMOOR_D, decode_AMO, string_OP_AMOORD, assemble_DUMMY
-		.word MASK_AMOXOR_D, MATCH_AMOXOR_D, decode_AMO, string_OP_AMOXORD, assemble_DUMMY
-		.word MASK_AMOMAX_D, MATCH_AMOMAX_D, decode_AMO, string_OP_AMOMAXD, assemble_DUMMY
-		.word MASK_AMOMIN_D, MATCH_AMOMIN_D, decode_AMO, string_OP_AMOMIND, assemble_DUMMY
-		.word MASK_AMOMAXU_D, MATCH_AMOMAXU_D, decode_AMO, string_OP_AMOMAXUD, assemble_DUMMY
-		.word MASK_AMOMINU_D, MATCH_AMOMINU_D, decode_AMO, string_OP_AMOMINUD, assemble_DUMMY
+	.word MASK_LR_D, MATCH_LR_D, decode_LRSC, string_OP_LRD, assemble_DUMMY
+	.word MASK_SC_D, MATCH_SC_D, decode_LRSC, string_OP_SCD, assemble_DUMMY
+	.word MASK_AMOSWAP_D, MATCH_AMOSWAP_D, decode_AMO, string_OP_AMOSWAPD, assemble_DUMMY
+	.word MASK_AMOADD_D, MATCH_AMOADD_D, decode_AMO, string_OP_AMOADDD, assemble_DUMMY
+	.word MASK_AMOAND_D, MATCH_AMOAND_D, decode_AMO, string_OP_AMOANDD, assemble_DUMMY
+	.word MASK_AMOOR_D, MATCH_AMOOR_D, decode_AMO, string_OP_AMOORD, assemble_DUMMY
+	.word MASK_AMOXOR_D, MATCH_AMOXOR_D, decode_AMO, string_OP_AMOXORD, assemble_DUMMY
+	.word MASK_AMOMAX_D, MATCH_AMOMAX_D, decode_AMO, string_OP_AMOMAXD, assemble_DUMMY
+	.word MASK_AMOMIN_D, MATCH_AMOMIN_D, decode_AMO, string_OP_AMOMIND, assemble_DUMMY
+	.word MASK_AMOMAXU_D, MATCH_AMOMAXU_D, decode_AMO, string_OP_AMOMAXUD, assemble_DUMMY
+	.word MASK_AMOMINU_D, MATCH_AMOMINU_D, decode_AMO, string_OP_AMOMINUD, assemble_DUMMY
 	#endif
 
-#endif /* ENABLE_RVA */
+	#endif /* ENABLE_RVA */
 
-# RVF / RVD / RVQ
-#ifdef ENABLE_RVF
+	# RVF / RVD / RVQ
+	#ifdef ENABLE_RVF
 	.word MASK_FLW, MATCH_FLW, decode_FL, string_OP_FLW, assemble_DUMMY
 	.word MASK_FSW, MATCH_FSW, decode_FS, string_OP_FSW, assemble_DUMMY
 	.word MASK_FMADD_S, MATCH_FMADD_S, decode_FMA, string_OP_FMADD_S, assemble_DUMMY
@@ -562,67 +562,67 @@ encoding_table:
 	.word MASK_FLE_S, MATCH_FLE_S, decode_FCMP, string_OP_FLE_S, assemble_DUMMY
 	.word MASK_FCLASS_S, MATCH_FCLASS_S, decode_FCLASS, string_OP_FCLASS_S, assemble_DUMMY
 	#ifdef ENABLE_RVD
-		.word MASK_FLD, MATCH_FLD, decode_FL, string_OP_FLD, assemble_DUMMY
-		.word MASK_FSD, MATCH_FSD, decode_FS, string_OP_FSD, assemble_DUMMY
-		.word MASK_FMADD_D, MATCH_FMADD_D, decode_FMA, string_OP_FMADD_D, assemble_DUMMY
-		.word MASK_FMSUB_D, MATCH_FMSUB_D, decode_FMA, string_OP_FMSUB_D, assemble_DUMMY
-		.word MASK_FNMADD_D, MATCH_FNMADD_D, decode_FMA, string_OP_FNMADD_D, assemble_DUMMY
-		.word MASK_FNMSUB_D, MATCH_FNMSUB_D, decode_FMA, string_OP_FNMSUB_D, assemble_DUMMY
-		.word MASK_FADD_D, MATCH_FADD_D, decode_FADD, string_OP_FADD_D, assemble_DUMMY
-		.word MASK_FSUB_D, MATCH_FSUB_D, decode_FADD, string_OP_FSUB_D, assemble_DUMMY
-		.word MASK_FMUL_D, MATCH_FMUL_D, decode_FADD, string_OP_FMUL_D, assemble_DUMMY
-		.word MASK_FDIV_D, MATCH_FDIV_D, decode_FADD, string_OP_FDIV_D, assemble_DUMMY
-		.word MASK_FSQRT_D, MATCH_FSQRT_D, decode_FSQRT, string_OP_FSQRT_D, assemble_DUMMY
-		.word MASK_FSGNJ_D, MATCH_FSGNJ_D, decode_FADD, string_OP_FSGNJ_D, assemble_DUMMY
-		.word MASK_FSGNJN_D, MATCH_FSGNJN_D, decode_FADD, string_OP_FSGNJN_D, assemble_DUMMY
-		.word MASK_FSGNJX_D, MATCH_FSGNJX_D, decode_FADD, string_OP_FSGNJX_D, assemble_DUMMY
-		.word MASK_FMIN_D, MATCH_FMIN_D, decode_FADD, string_OP_FMIN_D, assemble_DUMMY
-		.word MASK_FMAX_D, MATCH_FMAX_D, decode_FADD, string_OP_FMAX_D, assemble_DUMMY
-		.word MASK_FCVT_D_W, MATCH_FCVT_D_W, decode_FCVT_SW, string_OP_FCVT_D_W, assemble_DUMMY
-		.word MASK_FCVT_D_WU, MATCH_FCVT_D_WU, decode_FCVT_SW, string_OP_FCVT_D_WU, assemble_DUMMY
-		.word MASK_FCVT_W_D, MATCH_FCVT_W_D, decode_FCVT_WS, string_OP_FCVT_W_D, assemble_DUMMY
-		.word MASK_FCVT_WU_D, MATCH_FCVT_WU_D, decode_FCVT_WS, string_OP_FCVT_WU_D, assemble_DUMMY
-		.word MASK_FMV_X_D, MATCH_FMV_X_D, decode_FCVT_WS, string_OP_FMV_X_D, assemble_DUMMY
-		.word MASK_FMV_D_X, MATCH_FMV_D_X, decode_FCVT_SW, string_OP_FMV_D_X, assemble_DUMMY
-		.word MASK_FEQ_D, MATCH_FEQ_D, decode_FCMP, string_OP_FEQ_D, assemble_DUMMY
-		.word MASK_FLT_D, MATCH_FLT_D, decode_FCMP, string_OP_FLT_D, assemble_DUMMY
-		.word MASK_FLE_D, MATCH_FLE_D, decode_FCMP, string_OP_FLE_D, assemble_DUMMY
-		.word MASK_FCLASS_D, MATCH_FCLASS_D, decode_FCLASS, string_OP_FCLASS_D, assemble_DUMMY
-		#ifdef ENABLE_RVQ
-			.word MASK_FLQ, MATCH_FLQ, decode_FL, string_OP_FLQ, assemble_DUMMY
-			.word MASK_FSQ, MATCH_FSQ, decode_FS, string_OP_FSQ, assemble_DUMMY
-			.word MASK_FMADD_Q, MATCH_FMADD_Q, decode_FMA, string_OP_FMADD_Q, assemble_DUMMY
-			.word MASK_FMSUB_Q, MATCH_FMSUB_Q, decode_FMA, string_OP_FMSUB_Q, assemble_DUMMY
-			.word MASK_FNMADD_Q, MATCH_FNMADD_Q, decode_FMA, string_OP_FNMADD_Q, assemble_DUMMY
-			.word MASK_FNMSUB_Q, MATCH_FNMSUB_Q, decode_FMA, string_OP_FNMSUB_Q, assemble_DUMMY
-			.word MASK_FADD_Q, MATCH_FADD_Q, decode_FADD, string_OP_FADD_Q, assemble_DUMMY
-			.word MASK_FSUB_Q, MATCH_FSUB_Q, decode_FADD, string_OP_FSUB_Q, assemble_DUMMY
-			.word MASK_FMUL_Q, MATCH_FMUL_Q, decode_FADD, string_OP_FMUL_Q, assemble_DUMMY
-			.word MASK_FDIV_Q, MATCH_FDIV_Q, decode_FADD, string_OP_FDIV_Q, assemble_DUMMY
-			.word MASK_FSQRT_Q, MATCH_FSQRT_Q, decode_FSQRT, string_OP_FSQRT_Q, assemble_DUMMY
-			.word MASK_FSGNJ_Q, MATCH_FSGNJ_Q, decode_FADD, string_OP_FSGNJ_Q, assemble_DUMMY
-			.word MASK_FSGNJN_Q, MATCH_FSGNJN_Q, decode_FADD, string_OP_FSGNJN_Q, assemble_DUMMY
-			.word MASK_FSGNJX_Q, MATCH_FSGNJX_Q, decode_FADD, string_OP_FSGNJX_Q, assemble_DUMMY
-			.word MASK_FMIN_Q, MATCH_FMIN_Q, decode_FADD, string_OP_FMIN_Q, assemble_DUMMY
-			.word MASK_FMAX_Q, MATCH_FMAX_Q, decode_FADD, string_OP_FMAX_Q, assemble_DUMMY
-			.word MASK_FCVT_Q_W, MATCH_FCVT_Q_W, decode_FCVT_SW, string_OP_FCVT_Q_W, assemble_DUMMY
-			.word MASK_FCVT_Q_WU, MATCH_FCVT_Q_WU, decode_FCVT_SW, string_OP_FCVT_Q_WU, assemble_DUMMY
-			.word MASK_FCVT_W_Q, MATCH_FCVT_W_Q, decode_FCVT_WS, string_OP_FCVT_W_Q, assemble_DUMMY
-			.word MASK_FCVT_WU_Q, MATCH_FCVT_WU_Q, decode_FCVT_WS, string_OP_FCVT_WU_Q, assemble_DUMMY
-			#if XLEN >=128
-				.word MASK_FMV_X_Q, MATCH_FMV_X_Q, decode_FCVT_WS, string_OP_FMV_X_Q, assemble_DUMMY
-				.word MASK_FMV_Q_X, MATCH_FMV_Q_X, decode_FCVT_SW, string_OP_FMV_Q_X, assemble_DUMMY
-			#endif
-			.word MASK_FEQ_Q, MATCH_FEQ_Q, decode_FCMP, string_OP_FEQ_Q, assemble_DUMMY
-			.word MASK_FLT_Q, MATCH_FLT_Q, decode_FCMP, string_OP_FLT_Q, assemble_DUMMY
-			.word MASK_FLE_Q, MATCH_FLE_Q, decode_FCMP, string_OP_FLE_Q, assemble_DUMMY
-			.word MASK_FCLASS_Q, MATCH_FCLASS_Q, decode_FCLASS, string_OP_FCLASS_Q, assemble_DUMMY
-		#endif /* ENABLE_RVQ */
+	.word MASK_FLD, MATCH_FLD, decode_FL, string_OP_FLD, assemble_DUMMY
+	.word MASK_FSD, MATCH_FSD, decode_FS, string_OP_FSD, assemble_DUMMY
+	.word MASK_FMADD_D, MATCH_FMADD_D, decode_FMA, string_OP_FMADD_D, assemble_DUMMY
+	.word MASK_FMSUB_D, MATCH_FMSUB_D, decode_FMA, string_OP_FMSUB_D, assemble_DUMMY
+	.word MASK_FNMADD_D, MATCH_FNMADD_D, decode_FMA, string_OP_FNMADD_D, assemble_DUMMY
+	.word MASK_FNMSUB_D, MATCH_FNMSUB_D, decode_FMA, string_OP_FNMSUB_D, assemble_DUMMY
+	.word MASK_FADD_D, MATCH_FADD_D, decode_FADD, string_OP_FADD_D, assemble_DUMMY
+	.word MASK_FSUB_D, MATCH_FSUB_D, decode_FADD, string_OP_FSUB_D, assemble_DUMMY
+	.word MASK_FMUL_D, MATCH_FMUL_D, decode_FADD, string_OP_FMUL_D, assemble_DUMMY
+	.word MASK_FDIV_D, MATCH_FDIV_D, decode_FADD, string_OP_FDIV_D, assemble_DUMMY
+	.word MASK_FSQRT_D, MATCH_FSQRT_D, decode_FSQRT, string_OP_FSQRT_D, assemble_DUMMY
+	.word MASK_FSGNJ_D, MATCH_FSGNJ_D, decode_FADD, string_OP_FSGNJ_D, assemble_DUMMY
+	.word MASK_FSGNJN_D, MATCH_FSGNJN_D, decode_FADD, string_OP_FSGNJN_D, assemble_DUMMY
+	.word MASK_FSGNJX_D, MATCH_FSGNJX_D, decode_FADD, string_OP_FSGNJX_D, assemble_DUMMY
+	.word MASK_FMIN_D, MATCH_FMIN_D, decode_FADD, string_OP_FMIN_D, assemble_DUMMY
+	.word MASK_FMAX_D, MATCH_FMAX_D, decode_FADD, string_OP_FMAX_D, assemble_DUMMY
+	.word MASK_FCVT_D_W, MATCH_FCVT_D_W, decode_FCVT_SW, string_OP_FCVT_D_W, assemble_DUMMY
+	.word MASK_FCVT_D_WU, MATCH_FCVT_D_WU, decode_FCVT_SW, string_OP_FCVT_D_WU, assemble_DUMMY
+	.word MASK_FCVT_W_D, MATCH_FCVT_W_D, decode_FCVT_WS, string_OP_FCVT_W_D, assemble_DUMMY
+	.word MASK_FCVT_WU_D, MATCH_FCVT_WU_D, decode_FCVT_WS, string_OP_FCVT_WU_D, assemble_DUMMY
+	.word MASK_FMV_X_D, MATCH_FMV_X_D, decode_FCVT_WS, string_OP_FMV_X_D, assemble_DUMMY
+	.word MASK_FMV_D_X, MATCH_FMV_D_X, decode_FCVT_SW, string_OP_FMV_D_X, assemble_DUMMY
+	.word MASK_FEQ_D, MATCH_FEQ_D, decode_FCMP, string_OP_FEQ_D, assemble_DUMMY
+	.word MASK_FLT_D, MATCH_FLT_D, decode_FCMP, string_OP_FLT_D, assemble_DUMMY
+	.word MASK_FLE_D, MATCH_FLE_D, decode_FCMP, string_OP_FLE_D, assemble_DUMMY
+	.word MASK_FCLASS_D, MATCH_FCLASS_D, decode_FCLASS, string_OP_FCLASS_D, assemble_DUMMY
+	#ifdef ENABLE_RVQ
+	.word MASK_FLQ, MATCH_FLQ, decode_FL, string_OP_FLQ, assemble_DUMMY
+	.word MASK_FSQ, MATCH_FSQ, decode_FS, string_OP_FSQ, assemble_DUMMY
+	.word MASK_FMADD_Q, MATCH_FMADD_Q, decode_FMA, string_OP_FMADD_Q, assemble_DUMMY
+	.word MASK_FMSUB_Q, MATCH_FMSUB_Q, decode_FMA, string_OP_FMSUB_Q, assemble_DUMMY
+	.word MASK_FNMADD_Q, MATCH_FNMADD_Q, decode_FMA, string_OP_FNMADD_Q, assemble_DUMMY
+	.word MASK_FNMSUB_Q, MATCH_FNMSUB_Q, decode_FMA, string_OP_FNMSUB_Q, assemble_DUMMY
+	.word MASK_FADD_Q, MATCH_FADD_Q, decode_FADD, string_OP_FADD_Q, assemble_DUMMY
+	.word MASK_FSUB_Q, MATCH_FSUB_Q, decode_FADD, string_OP_FSUB_Q, assemble_DUMMY
+	.word MASK_FMUL_Q, MATCH_FMUL_Q, decode_FADD, string_OP_FMUL_Q, assemble_DUMMY
+	.word MASK_FDIV_Q, MATCH_FDIV_Q, decode_FADD, string_OP_FDIV_Q, assemble_DUMMY
+	.word MASK_FSQRT_Q, MATCH_FSQRT_Q, decode_FSQRT, string_OP_FSQRT_Q, assemble_DUMMY
+	.word MASK_FSGNJ_Q, MATCH_FSGNJ_Q, decode_FADD, string_OP_FSGNJ_Q, assemble_DUMMY
+	.word MASK_FSGNJN_Q, MATCH_FSGNJN_Q, decode_FADD, string_OP_FSGNJN_Q, assemble_DUMMY
+	.word MASK_FSGNJX_Q, MATCH_FSGNJX_Q, decode_FADD, string_OP_FSGNJX_Q, assemble_DUMMY
+	.word MASK_FMIN_Q, MATCH_FMIN_Q, decode_FADD, string_OP_FMIN_Q, assemble_DUMMY
+	.word MASK_FMAX_Q, MATCH_FMAX_Q, decode_FADD, string_OP_FMAX_Q, assemble_DUMMY
+	.word MASK_FCVT_Q_W, MATCH_FCVT_Q_W, decode_FCVT_SW, string_OP_FCVT_Q_W, assemble_DUMMY
+	.word MASK_FCVT_Q_WU, MATCH_FCVT_Q_WU, decode_FCVT_SW, string_OP_FCVT_Q_WU, assemble_DUMMY
+	.word MASK_FCVT_W_Q, MATCH_FCVT_W_Q, decode_FCVT_WS, string_OP_FCVT_W_Q, assemble_DUMMY
+	.word MASK_FCVT_WU_Q, MATCH_FCVT_WU_Q, decode_FCVT_WS, string_OP_FCVT_WU_Q, assemble_DUMMY
+	#if XLEN >=128
+	.word MASK_FMV_X_Q, MATCH_FMV_X_Q, decode_FCVT_WS, string_OP_FMV_X_Q, assemble_DUMMY
+	.word MASK_FMV_Q_X, MATCH_FMV_Q_X, decode_FCVT_SW, string_OP_FMV_Q_X, assemble_DUMMY
+	#endif
+	.word MASK_FEQ_Q, MATCH_FEQ_Q, decode_FCMP, string_OP_FEQ_Q, assemble_DUMMY
+	.word MASK_FLT_Q, MATCH_FLT_Q, decode_FCMP, string_OP_FLT_Q, assemble_DUMMY
+	.word MASK_FLE_Q, MATCH_FLE_Q, decode_FCMP, string_OP_FLE_Q, assemble_DUMMY
+	.word MASK_FCLASS_Q, MATCH_FCLASS_Q, decode_FCLASS, string_OP_FCLASS_Q, assemble_DUMMY
+	#endif /* ENABLE_RVQ */
 	#endif /* ENABLE_RVD */
-#endif /* ENABLE_RVF */
+	#endif /* ENABLE_RVF */
 
-# RVC
-#ifdef ENABLE_RVC
+	# RVC
+	#ifdef ENABLE_RVC
 	.word MASK_C_LW, MATCH_C_LW, decode_EMPTY, string_OP_C_LW, assemble_DUMMY
 	.word MASK_C_SW, MATCH_C_SW, decode_EMPTY, string_OP_C_SW, assemble_DUMMY
 	.word MASK_C_ADDI, MATCH_C_ADDI, decode_EMPTY, string_OP_C_ADDI, assemble_DUMMY
@@ -660,43 +660,43 @@ encoding_table:
 	.word MASK_C_LDSP, MATCH_C_LDSP, decode_EMPTY, string_OP_C_LDSP, assemble_DUMMY
 	.word MASK_C_SDSP, MATCH_C_SDSP, decode_EMPTY, string_OP_C_SDSP, assemble_DUMMY
 	#ifdef ENABLE_RVF
-		.word MASK_C_FLD, MATCH_C_FLD, decode_EMPTY, string_OP_C_FLD, assemble_DUMMY
-		.word MASK_C_FSD, MATCH_C_FSD, decode_EMPTY, string_OP_C_FSD, assemble_DUMMY
-		.word MASK_C_FLW, MATCH_C_FLW, decode_EMPTY, string_OP_C_FLW, assemble_DUMMY
-		.word MASK_C_FSW, MATCH_C_FSW, decode_EMPTY, string_OP_C_FSW, assemble_DUMMY
-		.word MASK_C_FLWSP, MATCH_C_FLWSP, decode_EMPTY, string_OP_C_FLWSP, assemble_DUMMY
-		.word MASK_C_FSWSP, MATCH_C_FSWSP, decode_EMPTY, string_OP_C_FSWSP, assemble_DUMMY
-		.word MASK_C_FLDSP, MATCH_C_FLDSP, decode_EMPTY, string_OP_C_FLDSP, assemble_DUMMY
-		.word MASK_C_FSDSP, MATCH_C_FSDSP, decode_EMPTY, string_OP_C_FSDSP, assemble_DUMMY
+	.word MASK_C_FLD, MATCH_C_FLD, decode_EMPTY, string_OP_C_FLD, assemble_DUMMY
+	.word MASK_C_FSD, MATCH_C_FSD, decode_EMPTY, string_OP_C_FSD, assemble_DUMMY
+	.word MASK_C_FLW, MATCH_C_FLW, decode_EMPTY, string_OP_C_FLW, assemble_DUMMY
+	.word MASK_C_FSW, MATCH_C_FSW, decode_EMPTY, string_OP_C_FSW, assemble_DUMMY
+	.word MASK_C_FLWSP, MATCH_C_FLWSP, decode_EMPTY, string_OP_C_FLWSP, assemble_DUMMY
+	.word MASK_C_FSWSP, MATCH_C_FSWSP, decode_EMPTY, string_OP_C_FSWSP, assemble_DUMMY
+	.word MASK_C_FLDSP, MATCH_C_FLDSP, decode_EMPTY, string_OP_C_FLDSP, assemble_DUMMY
+	.word MASK_C_FSDSP, MATCH_C_FSDSP, decode_EMPTY, string_OP_C_FSDSP, assemble_DUMMY
 	#endif /* ENABLE_RVF */
-#endif /* ENABLE_RVC */
+	#endif /* ENABLE_RVC */
 
-# Zifencei
-#ifdef ENABLE_RVZifencei
+	# Zifencei
+	#ifdef ENABLE_RVZifencei
 	.word MASK_FENCE_I, MATCH_FENCE_I, decode_FENCE_I, string_OP_FENCE_I, assemble_VOID
-#endif /* ENABLE_RVZifencei */
+	#endif /* ENABLE_RVZifencei */
 
-# Zicsr
-#ifdef ENABLE_RVZicsr
+	# Zicsr
+	#ifdef ENABLE_RVZicsr
 	.word MASK_CSRRW, MATCH_CSRRW, decode_CSR, string_OP_CSRRW, assemble_DUMMY
 	.word MASK_CSRRS, MATCH_CSRRS, decode_CSR, string_OP_CSRRS, assemble_DUMMY
 	.word MASK_CSRRC, MATCH_CSRRC, decode_CSR, string_OP_CSRRC, assemble_DUMMY
 	.word MASK_CSRRWI, MATCH_CSRRWI, decode_CSRI, string_OP_CSRRWI, assemble_DUMMY
 	.word MASK_CSRRSI, MATCH_CSRRSI, decode_CSRI, string_OP_CSRRSI, assemble_DUMMY
 	.word MASK_CSRRCI, MATCH_CSRRCI, decode_CSRI, string_OP_CSRRCI, assemble_DUMMY
-#endif /* ENABLE_RVZicsr */
+	#endif /* ENABLE_RVZicsr */
 
-# Privileged
-#ifdef ENABLE_RVPRIV
+	# Privileged
+	#ifdef ENABLE_RVPRIV
 	.word MASK_WFI, MATCH_WFI, decode_WFI, string_OP_WFI, assemble_VOID
 	.word MASK_MRET, MATCH_MRET, decode_MRET, string_OP_MRET, assemble_VOID
 	.word MASK_SRET, MATCH_SRET, decode_SRET, string_OP_SRET, assemble_VOID
 	.word MASK_SFENCE_VM, MATCH_SFENCE_VM, decode_SFENCE_VM, string_OP_SFENCE_VM, assemble_VOID
 	.word MASK_SFENCE_VMA, MATCH_SFENCE_VMA, decode_SFENCE_VMA, string_OP_SFENCE_VMA,assemble_VOID
-#endif /* ENABLE_RVPRIV */
+	#endif /* ENABLE_RVPRIV */
 
-# table end marker
-.word 0, 0, 0, 0, 0
-.size encoding_table, .-encoding_table
+	# table end marker
+	.word 0, 0, 0, 0, 0
+	.size encoding_table, .-encoding_table
 
-#endif /* #if defined (WITH_CMD_D) || defined (WITH_CMD_A) */
+	#endif /* #if defined (WITH_CMD_D) || defined (WITH_CMD_A) */

--- a/src/error.S
+++ b/src/error.S
@@ -1,13 +1,13 @@
-#include "vmon/config.h"
+	#include "vmon/config.h"
 
 
-.global error_param
-.global error_unknown_command
+	.global error_param
+	.global error_unknown_command
 
 
-.data
+	.data
 error_param:			.string "ERROR: parameter missing or invalid";
-.size error_param, .-error_param
+	.size error_param, .-error_param
 error_unknown_command:	.string "ERROR: unknown command";
-.size error_unknown_command, .-error_unknown_command
+	.size error_unknown_command, .-error_unknown_command
 

--- a/src/main.S
+++ b/src/main.S
@@ -1,211 +1,211 @@
-/*
-    VMON - a RISC-V machine code monitor written in RISC-V assembly code
-*/
+	/*
+	VMON - a RISC-V machine code monitor written in RISC-V assembly code
+	*/
 
 
-#include "vmon/config.h"
-#include "vmon/drivers/uart/ns16550.h"
-#include "vmon/ASCII.h"
+	#include "vmon/config.h"
+	#include "vmon/drivers/uart/ns16550.h"
+	#include "vmon/ASCII.h"
 
 
-.global start
-.global main_prompt
-.global string_asm_sep1
-.global string_asm_sep2
-.global string_asm_comment
-.global string_OP_UNKNOWN
-.global start_data
-.global start_bss
+	.global start
+	.global main_prompt
+	.global string_asm_sep1
+	.global string_asm_sep2
+	.global string_asm_comment
+	.global string_OP_UNKNOWN
+	.global start_data
+	.global start_bss
 
 
-.text
+	.text
 
-/*
-    application entry point
+	/*
+	application entry point
 
-    s5 = address of current instruction being disassembled   
-*/
+	s5 = address of current instruction being disassembled	 
+	*/
 start:
 
-    # I am alive
-    # try to output one char in the simplest way possible
-    # this will happen on all harts
-#ifdef DEBUG
-    li      t1, UART_BASE                  
-    li      t0, UART_MODE_8N1
-    sb      t0, UART_REG_LSR(t1)
-    li      t0, '*'
-    sb      t0, UART_REG_THR(t1)      
-#endif
+	# I am alive
+	# try to output one char in the simplest way possible
+	# this will happen on all harts
+	#ifdef DEBUG
+	li		t1, UART_BASE				   
+	li		t0, UART_MODE_8N1
+	sb		t0, UART_REG_LSR(t1)
+	li		t0, '*'
+	sb		t0, UART_REG_THR(t1)	  
+	#endif
 
-#ifdef BARE_METAL
-    #ifdef HW_QEMU
-        # run only on hart 0
-        # this works only in M-mode
-        csrr    t0, mhartid
-        bnez    t0, end
-    #endif
+	#ifdef BARE_METAL
+	#ifdef HW_QEMU
+	# run only on hart 0
+	# this works only in M-mode
+	csrr	t0, mhartid
+	bnez	t0, end
+	#endif
 
-    #ifdef HW_VF2
-        # TODO: csrr is not allowed when called from U-Boot on VF2 (S-mode)    
-    #endif
+	#ifdef HW_VF2
+	# TODO: csrr is not allowed when called from U-Boot on VF2 (S-mode)	   
+	#endif
 
-    # set up a stack 
-    mv      t0, sp                      # save caller sp for later
-    la      sp, stack + STACK_SIZE      # point to end of our new stack
-#endif /* BARE_METAL */
+	# set up a stack 
+	mv		t0, sp						# save caller sp for later
+	la		sp, stack + STACK_SIZE		# point to end of our new stack
+	#endif /* BARE_METAL */
 
-    # save registers on new stack
-    addi    sp, sp, -(XLEN_BYTES*31)         
-    SAVE_X  ra, 0(sp)  
-    SAVE_X  t0, (XLEN_BYTES*1)(sp)      # the original sp from above
-    SAVE_X  x3, (XLEN_BYTES*2)(sp)
-    SAVE_X  x4, (XLEN_BYTES*3)(sp)
-    SAVE_X  x5, (XLEN_BYTES*4)(sp)
-    SAVE_X  x6, (XLEN_BYTES*5)(sp)
-    SAVE_X  x7, (XLEN_BYTES*6)(sp)
-    SAVE_X  x8, (XLEN_BYTES*7)(sp)
-    SAVE_X  x9, (XLEN_BYTES*8)(sp)
-    SAVE_X  x10, (XLEN_BYTES*9)(sp)
-    SAVE_X  x11, (XLEN_BYTES*10)(sp)
-    SAVE_X  x12, (XLEN_BYTES*11)(sp)
-    SAVE_X  x13, (XLEN_BYTES*12)(sp)
-    SAVE_X  x14, (XLEN_BYTES*13)(sp)
-    SAVE_X  x15, (XLEN_BYTES*14)(sp)
-    SAVE_X  x16, (XLEN_BYTES*15)(sp)
-    SAVE_X  x17, (XLEN_BYTES*16)(sp)
-    SAVE_X  x18, (XLEN_BYTES*17)(sp)
-    SAVE_X  x19, (XLEN_BYTES*18)(sp)
-    SAVE_X  x20, (XLEN_BYTES*19)(sp)
-    SAVE_X  x21, (XLEN_BYTES*20)(sp)
-    SAVE_X  x22, (XLEN_BYTES*21)(sp)
-    SAVE_X  x23, (XLEN_BYTES*22)(sp)
-    SAVE_X  x24, (XLEN_BYTES*23)(sp)
-    SAVE_X  x25, (XLEN_BYTES*24)(sp)
-    SAVE_X  x26, (XLEN_BYTES*25)(sp)
-    SAVE_X  x27, (XLEN_BYTES*26)(sp)
-    SAVE_X  x28, (XLEN_BYTES*27)(sp)
-    SAVE_X  x29, (XLEN_BYTES*28)(sp)
-    SAVE_X  x30, (XLEN_BYTES*29)(sp)
-    SAVE_X  x31, (XLEN_BYTES*30)(sp)
+	# save registers on new stack
+	addi	sp, sp, -(XLEN_BYTES*31)		 
+	SAVE_X	ra, 0(sp)  
+	SAVE_X	t0, (XLEN_BYTES*1)(sp)		# the original sp from above
+	SAVE_X	x3, (XLEN_BYTES*2)(sp)
+	SAVE_X	x4, (XLEN_BYTES*3)(sp)
+	SAVE_X	x5, (XLEN_BYTES*4)(sp)
+	SAVE_X	x6, (XLEN_BYTES*5)(sp)
+	SAVE_X	x7, (XLEN_BYTES*6)(sp)
+	SAVE_X	x8, (XLEN_BYTES*7)(sp)
+	SAVE_X	x9, (XLEN_BYTES*8)(sp)
+	SAVE_X	x10, (XLEN_BYTES*9)(sp)
+	SAVE_X	x11, (XLEN_BYTES*10)(sp)
+	SAVE_X	x12, (XLEN_BYTES*11)(sp)
+	SAVE_X	x13, (XLEN_BYTES*12)(sp)
+	SAVE_X	x14, (XLEN_BYTES*13)(sp)
+	SAVE_X	x15, (XLEN_BYTES*14)(sp)
+	SAVE_X	x16, (XLEN_BYTES*15)(sp)
+	SAVE_X	x17, (XLEN_BYTES*16)(sp)
+	SAVE_X	x18, (XLEN_BYTES*17)(sp)
+	SAVE_X	x19, (XLEN_BYTES*18)(sp)
+	SAVE_X	x20, (XLEN_BYTES*19)(sp)
+	SAVE_X	x21, (XLEN_BYTES*20)(sp)
+	SAVE_X	x22, (XLEN_BYTES*21)(sp)
+	SAVE_X	x23, (XLEN_BYTES*22)(sp)
+	SAVE_X	x24, (XLEN_BYTES*23)(sp)
+	SAVE_X	x25, (XLEN_BYTES*24)(sp)
+	SAVE_X	x26, (XLEN_BYTES*25)(sp)
+	SAVE_X	x27, (XLEN_BYTES*26)(sp)
+	SAVE_X	x28, (XLEN_BYTES*27)(sp)
+	SAVE_X	x29, (XLEN_BYTES*28)(sp)
+	SAVE_X	x30, (XLEN_BYTES*29)(sp)
+	SAVE_X	x31, (XLEN_BYTES*30)(sp)
 
-#ifdef BARE_METAL
-    jal     setup_trap_handler
-#endif /* BARE_METAL */
+	#ifdef BARE_METAL
+	jal		setup_trap_handler
+	#endif /* BARE_METAL */
 
-    # init UART 
-    jal     uart_init
+	# init UART 
+	jal		uart_init
 
-    # startup message
-    la      a0, string_startup
-    jal     print_string
+	# startup message
+	la		a0, string_startup
+	jal		print_string
 
-    # main loop
+	# main loop
 main_prompt:
-    jal     print_newline
+	jal		print_newline
 
 main_prompt_no_newline:
-    la      a0, string_prompt
-    jal     print_string
+	la		a0, string_prompt
+	jal		print_string
 
-    jal     uart_getline
-    jal     skip_whitespace
-    
-    lb      t1, 0(a0)
-    addi    a0, a0, 1
+	jal		uart_getline
+	jal		skip_whitespace
+	
+	lb		t1, 0(a0)
+	addi	a0, a0, 1
 
-#ifdef WITH_CMD_A
-    li      t0, 'a'
-    beq     t1, t0, cmd_A
-#endif
+	#ifdef WITH_CMD_A
+	li		t0, 'a'
+	beq		t1, t0, cmd_A
+	#endif
 
-#ifdef WITH_CMD_C
-    li      t0, 'c'
-    beq     t1, t0, cmd_C
-#endif
+	#ifdef WITH_CMD_C
+	li		t0, 'c'
+	beq		t1, t0, cmd_C
+	#endif
 
-#ifdef WITH_CMD_D
-    li      t0, 'd'
-    beq     t1, t0, cmd_D
-#endif
+	#ifdef WITH_CMD_D
+	li		t0, 'd'
+	beq		t1, t0, cmd_D
+	#endif
 
-#ifdef WITH_CMD_F
-    li      t0, 'f'
-    beq     t1, t0, cmd_F
-#endif
+	#ifdef WITH_CMD_F
+	li		t0, 'f'
+	beq		t1, t0, cmd_F
+	#endif
 
-#ifdef WITH_CMD_G
-    li      t0, 'g'
-    beq     t1, t0, cmd_G
-#endif
+	#ifdef WITH_CMD_G
+	li		t0, 'g'
+	beq		t1, t0, cmd_G
+	#endif
 
-#ifdef WITH_CMD_H
-    li      t0, 'h'
-    beq     t1, t0, cmd_H
-#endif
+	#ifdef WITH_CMD_H
+	li		t0, 'h'
+	beq		t1, t0, cmd_H
+	#endif
 
-#ifdef WITH_CMD_I
-    li      t0, 'i'
-    beq     t1, t0, cmd_I
-#endif
+	#ifdef WITH_CMD_I
+	li		t0, 'i'
+	beq		t1, t0, cmd_I
+	#endif
 
-#ifdef WITH_CMD_M
-    li      t0, 'm'
-    beq     t1, t0, cmd_M
-#endif
+	#ifdef WITH_CMD_M
+	li		t0, 'm'
+	beq		t1, t0, cmd_M
+	#endif
 
-#ifdef WITH_CMD_P
-    li      t0, 'p'
-    beq     t1, t0, cmd_P
-#endif
+	#ifdef WITH_CMD_P
+	li		t0, 'p'
+	beq		t1, t0, cmd_P
+	#endif
 
-#ifdef WITH_CMD_X
-    li      t0, 'x'
-    beq     t1, t0, cmd_X
-#endif
+	#ifdef WITH_CMD_X
+	li		t0, 'x'
+	beq		t1, t0, cmd_X
+	#endif
 
-    # no command given, user only hit return
-    li      t0, ASCII_RETURN
-    beq     t1, t0, main_prompt_no_newline
+	# no command given, user only hit return
+	li		t0, ASCII_RETURN
+	beq		t1, t0, main_prompt_no_newline
 
 unknown_command:
-    la      a0, error_unknown_command
-    jal     print_string
-    j       main_prompt
-    # end of main loop
+	la		a0, error_unknown_command
+	jal		print_string
+	j		main_prompt
+	# end of main loop
 
 
-#ifdef BARE_METAL
-    # only if hart !=0
+	#ifdef BARE_METAL
+	# only if hart !=0
 end: 
-    wfi
-    j       end
-#endif /* BARE_METAL */
-.size start, .-start
+	wfi
+	j		end
+	#endif /* BARE_METAL */
+	.size start, .-start
 
 
-.data
+	.data
 start_data:
 
-string_startup:     .string "\nVMON - RISC-V machine code monitor";
-.size string_startup, .-string_startup
-string_prompt:      .string "> ";
-.size string_prompt, .-string_prompt
+string_startup:		.string "\nVMON - RISC-V machine code monitor";
+	.size string_startup, .-string_startup
+string_prompt:		.string "> ";
+	.size string_prompt, .-string_prompt
 
-string_asm_sep1:    .string ":";
-.size string_asm_sep1, .-string_asm_sep1
-#string_asm_sep2:    .string "\t";
-string_asm_sep2:    .string " ";
-.size string_asm_sep2, .-string_asm_sep2
+string_asm_sep1:	.string ":";
+	.size string_asm_sep1, .-string_asm_sep1
+	#string_asm_sep2:	 .string "\t";
+string_asm_sep2:	.string " ";
+	.size string_asm_sep2, .-string_asm_sep2
 string_asm_comment: .string "\t# ";
-.size string_asm_comment, .-string_asm_comment
+	.size string_asm_comment, .-string_asm_comment
 
-.bss
+	.bss
 start_bss:
-.align 8
-.comm last_address, XLEN_BYTES  # last address used in m or d command
-.size last_address, XLEN_BYTES
-        
-.align 8
-.comm stack, STACK_SIZE         # our execution stack
-.size stack, STACK_SIZE
+	.align 8
+	.comm last_address, XLEN_BYTES	# last address used in m or d command
+	.size last_address, XLEN_BYTES
+	
+	.align 8
+	.comm stack, STACK_SIZE			# our execution stack
+	.size stack, STACK_SIZE

--- a/src/math.S
+++ b/src/math.S
@@ -1,51 +1,51 @@
-#include "vmon/config.h"
+	#include "vmon/config.h"
 
 
-.global divrem
+	.global divrem
 
-.text
+	.text
 
-# Unsigned integer division without using M extension
-# Thanks to Bruce Hoult!
-# in: a0 = dividend
-# in: a1 = divisor
-# out: a0 = quotient 
-# out: a1 = remainder
-# clobbered: a2, a3, a4, a5
+	# Unsigned integer division without using M extension
+	# Thanks to Bruce Hoult!
+	# in: a0 = dividend
+	# in: a1 = divisor
+	# out: a0 = quotient 
+	# out: a1 = remainder
+	# clobbered: a2, a3, a4, a5
 divrem:
-    # check for division by zero, if so immediately return
-    beqz    a1, divrem_zero
-    
-    mv      a2, a0          # N = dividend
-    mv      a3, a1          # D = divisor
-    li      a0, 0           # Q = 0 (quotient)
-    li      a1, 0           # R = 0 (remainder)
-    li      a5, 1           # bit mask: bit = 1
-    slli    a5, a5, XLEN-1  # Set bit to the highest bit position
+	# check for division by zero, if so immediately return
+	beqz	a1, divrem_zero
+	
+	mv		a2, a0			# N = dividend
+	mv		a3, a1			# D = divisor
+	li		a0, 0			# Q = 0 (quotient)
+	li		a1, 0			# R = 0 (remainder)
+	li		a5, 1			# bit mask: bit = 1
+	slli	a5, a5, XLEN-1	# Set bit to the highest bit position
 
 divrem_loop:
-    # Shift remainder left by 1
-    slli    a1, a1, 1
+	# Shift remainder left by 1
+	slli	a1, a1, 1
 
-    # Isolate the highest bit of the dividend (N)
-    and     a4, a2, a5
-    snez    a4, a4         # Set tmp to 1 if bit is set, 0 otherwise
-    add     a1, a1, a4     # Add the bit to the remainder
+	# Isolate the highest bit of the dividend (N)
+	and		a4, a2, a5
+	snez	a4, a4		   # Set tmp to 1 if bit is set, 0 otherwise
+	add		a1, a1, a4	   # Add the bit to the remainder
 
-    # Check if remainder (R) is greater than or equal to divisor (D)
-    bltu    a1, a3, divrem_continue
-    sub     a1, a1, a3     # Subtract divisor from remainder
-    add     a0, a0, a5     # Add bit to quotient
+	# Check if remainder (R) is greater than or equal to divisor (D)
+	bltu	a1, a3, divrem_continue
+	sub		a1, a1, a3	   # Subtract divisor from remainder
+	add		a0, a0, a5	   # Add bit to quotient
 
 divrem_continue:
-    # Shift the bit mask to the right
-    srli    a5, a5, 1
-    bnez    a5, divrem_loop
+	# Shift the bit mask to the right
+	srli	a5, a5, 1
+	bnez	a5, divrem_loop
 
-    ret
+	ret
 
 divrem_zero:
-    li      a0, 0           # Return quotient = 0 (or some error code if needed)
-    ret
+	li		a0, 0			# Return quotient = 0 (or some error code if needed)
+	ret
 
-.size divrem, .-divrem
+	.size divrem, .-divrem

--- a/src/parse.S
+++ b/src/parse.S
@@ -1,90 +1,90 @@
-#include "vmon/config.h"
-#include "vmon/ASCII.h"
+	#include "vmon/config.h"
+	#include "vmon/ASCII.h"
 
 
-.global skip_whitespace
-.global get_hex_addr
-.global find_insn_name_end
-.global is_ascii
+	.global skip_whitespace
+	.global get_hex_addr
+	.global find_insn_name_end
+	.global is_ascii
 
-.text
+	.text
 
 
-# in: buffer ptr in a0
+	# in: buffer ptr in a0
 skip_whitespace:
-    li      t0, ' '
-    li      t1, '\t'
+	li		t0, ' '
+	li		t1, '\t'
 skip_whitespace_next:
-    lb      t2, 0(a0)               # get byte from buffer
-    beq     t2, t0, skip_whitespace_advance 
-    beq     t2, t1, skip_whitespace_advance
-    j       skip_whitespace_done
+	lb		t2, 0(a0)				# get byte from buffer
+	beq		t2, t0, skip_whitespace_advance 
+	beq		t2, t1, skip_whitespace_advance
+	j		skip_whitespace_done
 skip_whitespace_advance:
-    addi    a0, a0, 1               # advance buffer pointer
-    j       skip_whitespace_next    
+	addi	a0, a0, 1				# advance buffer pointer
+	j		skip_whitespace_next	
 skip_whitespace_done:
-    ret
-.size skip_whitespace, .-skip_whitespace
+	ret
+	.size skip_whitespace, .-skip_whitespace
 
 
-# in: buffer ptr in a0
-# out: ptr to end of word in a0
+	# in: buffer ptr in a0
+	# out: ptr to end of word in a0
 find_insn_name_end:
-    lb      t0, 0(a0)
-    # accept '.'
-    li      t1, '.'
-    beq     t0, t1, find_insn_name_end_valid_char
-    # accept a-z
-    li      t1, 'a'
-    blt     t0, t1, find_insn_name_end_done
-    li      t1, 'z'
-    bgt     t0, t1, find_insn_name_end_done
+	lb		t0, 0(a0)
+	# accept '.'
+	li		t1, '.'
+	beq		t0, t1, find_insn_name_end_valid_char
+	# accept a-z
+	li		t1, 'a'
+	blt		t0, t1, find_insn_name_end_done
+	li		t1, 'z'
+	bgt		t0, t1, find_insn_name_end_done
 find_insn_name_end_valid_char:
-    addi    a0, a0, 1
-    j       find_insn_name_end    
+	addi	a0, a0, 1
+	j		find_insn_name_end	  
 find_insn_name_end_done:
-    ret
-.size find_insn_name_end, .-find_insn_name_end
+	ret
+	.size find_insn_name_end, .-find_insn_name_end
 
 
-# in: buffer ptr in a0
-# out: buffer ptr in a0
-# out: parsed address value in a1
-# out: error code in a2 (OK=0)
+	# in: buffer ptr in a0
+	# out: buffer ptr in a0
+	# out: parsed address value in a1
+	# out: error code in a2 (OK=0)
 get_hex_addr:
-    li      a1, 0                   # reset address value
-    li      a2, -1                  # set error code
+	li		a1, 0					# reset address value
+	li		a2, -1					# set error code
 get_hex_addr_next_byte:
-    lb      t0, 0(a0)               # get byte from buffer
-    li      t1, ' '                 # end parsing at next space or return
-    beq     t0, t1, get_hex_addr_return      
-    li      t1, ASCII_RETURN
-    beq     t0, t1, get_hex_addr_return      
-    li      t1, '0'                 
-    blt     t0, t1, get_hex_addr_return_error
-    li      t1, '9'
-    bgt     t0, t1, get_hex_addr_check_alpha    
-    # got a digit
-    li      a2, 0                   # clear error code
-    sll     a1, a1, 4   
-    addi    t0, t0, -48
-    or      a1, a1, t0
-    addi    a0, a0 ,1               # advance buffer ptr
-    j       get_hex_addr_next_byte
+	lb		t0, 0(a0)				# get byte from buffer
+	li		t1, ' '					# end parsing at next space or return
+	beq		t0, t1, get_hex_addr_return		 
+	li		t1, ASCII_RETURN
+	beq		t0, t1, get_hex_addr_return		 
+	li		t1, '0'					
+	blt		t0, t1, get_hex_addr_return_error
+	li		t1, '9'
+	bgt		t0, t1, get_hex_addr_check_alpha	
+	# got a digit
+	li		a2, 0					# clear error code
+	sll		a1, a1, 4	
+	addi	t0, t0, -48
+	or		a1, a1, t0
+	addi	a0, a0 ,1				# advance buffer ptr
+	j		get_hex_addr_next_byte
 get_hex_addr_check_alpha:
-    li      t1, 'a'
-    blt     t0, t1, get_hex_addr_return_error
-    li      t1, 'f'
-    bgt     t0, t1, get_hex_addr_return_error    
-    # got a valid alpha
-    li      a2, 0                   # clear error code
-    sll     a1, a1, 4   
-    addi    t0, t0, -87
-    or      a1, a1, t0
-    addi    a0, a0 ,1               # advance buffer ptr
-    j       get_hex_addr_next_byte
- get_hex_addr_return_error:
-    li      a2, -1
- get_hex_addr_return:   
-    ret	
-.size get_hex_addr, .-get_hex_addr
+	li		t1, 'a'
+	blt		t0, t1, get_hex_addr_return_error
+	li		t1, 'f'
+	bgt		t0, t1, get_hex_addr_return_error	 
+	# got a valid alpha
+	li		a2, 0					# clear error code
+	sll		a1, a1, 4	
+	addi	t0, t0, -87
+	or		a1, a1, t0
+	addi	a0, a0 ,1				# advance buffer ptr
+	j		get_hex_addr_next_byte
+get_hex_addr_return_error:
+	li		a2, -1
+get_hex_addr_return:   
+	ret	
+	.size get_hex_addr, .-get_hex_addr

--- a/src/print.S
+++ b/src/print.S
@@ -1,223 +1,223 @@
-#include "vmon/config.h"
-#include "vmon/ASCII.h"
+	#include "vmon/config.h"
+	#include "vmon/ASCII.h"
 
 
-.global print_hex
-.global print_hex_raw
-.global print_hex_byte
-.global print_ascii
-.global print_char
-.global print_string
-.global print_decimal
-.global print_comma
-.global print_newline
-.global out_buf
+	.global print_hex
+	.global print_hex_raw
+	.global print_hex_byte
+	.global print_ascii
+	.global print_char
+	.global print_string
+	.global print_decimal
+	.global print_comma
+	.global print_newline
+	.global out_buf
 
 
-#define DEC_BUFFER_SIZE      32
-#define OUT_BUFFER_SIZE      128
+	#define DEC_BUFFER_SIZE		 32
+	#define OUT_BUFFER_SIZE		 128
 
-.text
+	.text
 
 print_comma:
-    addi    sp, sp, -(XLEN_BYTES*1)             
-    SAVE_X  ra, 0(sp)
-    li      a0, ','
-    jal     print_char
-#ifdef SPACE_AFTER_COMMA
-    li      a0, ' '
-    jal     print_char
-#endif
-    LOAD_X  ra, 0(sp)             
-    addi    sp, sp, (XLEN_BYTES*1)
-    ret
-.size print_comma, .-print_comma
+	addi	sp, sp, -(XLEN_BYTES*1)				
+	SAVE_X	ra, 0(sp)
+	li		a0, ','
+	jal		print_char
+	#ifdef SPACE_AFTER_COMMA
+	li		a0, ' '
+	jal		print_char
+	#endif
+	LOAD_X	ra, 0(sp)			  
+	addi	sp, sp, (XLEN_BYTES*1)
+	ret
+	.size print_comma, .-print_comma
 
 
 print_newline:
-    addi    sp, sp, -(XLEN_BYTES*1)
-    SAVE_X  ra, 0(sp)
-#ifdef USE_CRLF
-    li      a0, ASCII_RETURN
-    jal     print_char
-#endif
-    li      a0, ASCII_NEWLINE
-    jal     print_char
-    LOAD_X  ra, 0(sp)
-    addi    sp, sp, (XLEN_BYTES*1)
-    ret
-.size print_newline, .-print_newline
+	addi	sp, sp, -(XLEN_BYTES*1)
+	SAVE_X	ra, 0(sp)
+	#ifdef USE_CRLF
+	li		a0, ASCII_RETURN
+	jal		print_char
+	#endif
+	li		a0, ASCII_NEWLINE
+	jal		print_char
+	LOAD_X	ra, 0(sp)
+	addi	sp, sp, (XLEN_BYTES*1)
+	ret
+	.size print_newline, .-print_newline
 
 
-# in: print value in a0 in hex with "0x" prefix
+	# in: print value in a0 in hex with "0x" prefix
 print_hex:
-    addi    sp, sp, -(XLEN_BYTES*2)             
-    SAVE_X  ra, 0(sp)
-    SAVE_X  s1, (XLEN_BYTES*1)(sp)
-    # print "0x"
-    mv      s1, a0                      # save a0 for later
-    li      a0, '0'
-    jal     print_char
-    li      a0, 'x'
-    jal     print_char
-    mv      a0, s1                      # restore a0
-    # print value
-    jal     print_hex_raw
-    LOAD_X  ra, 0(sp)            
-    LOAD_X  s1, (XLEN_BYTES*1)(sp)        
-    addi    sp, sp, (XLEN_BYTES*2)
-    ret
-.size print_hex, .-print_hex
+	addi	sp, sp, -(XLEN_BYTES*2)				
+	SAVE_X	ra, 0(sp)
+	SAVE_X	s1, (XLEN_BYTES*1)(sp)
+	# print "0x"
+	mv		s1, a0						# save a0 for later
+	li		a0, '0'
+	jal		print_char
+	li		a0, 'x'
+	jal		print_char
+	mv		a0, s1						# restore a0
+	# print value
+	jal		print_hex_raw
+	LOAD_X	ra, 0(sp)			 
+	LOAD_X	s1, (XLEN_BYTES*1)(sp)		  
+	addi	sp, sp, (XLEN_BYTES*2)
+	ret
+	.size print_hex, .-print_hex
 
 
-# in: print value in a0 in hex
-# no trailing zeroes, no prefix
+	# in: print value in a0 in hex
+	# no trailing zeroes, no prefix
 print_hex_raw:
-    addi    sp, sp, -(XLEN_BYTES*1)             
-    SAVE_X  ra, 0(sp)
-    # terminate buffer at the end
-    # TODO: do buffer termination only once
-    la      t2, dec_buf
-    addi    t2, t2, (DEC_BUFFER_SIZE-1)
-    sb      zero, 0(t2)
-    # print to output buffer backwards
+	addi	sp, sp, -(XLEN_BYTES*1)				
+	SAVE_X	ra, 0(sp)
+	# terminate buffer at the end
+	# TODO: do buffer termination only once
+	la		t2, dec_buf
+	addi	t2, t2, (DEC_BUFFER_SIZE-1)
+	sb		zero, 0(t2)
+	# print to output buffer backwards
 print_hex_new_next_nibble:
-    addi    t2, t2, -1 
-    andi    t0, a0, 0x0f
-    # digit < 10?
-    sltiu   t3, t0, 10
-    bnez    t3, print_hex_new_decimal
-    addi    t0, t0, 39
-print_hex_new_decimal:    
-    addi    t0, t0, 48
-    sb      t0, 0(t2)                       # to buffer
-    srli    a0, a0, 4                       # next nibble
-    bnez    a0, print_hex_new_next_nibble   # only if more to come
-    # print buffer
-    mv      a0, t2
-    jal     print_string
-    LOAD_X  ra, 0(sp)             
-    addi    sp, sp, (XLEN_BYTES*1)
-    ret
-.size print_hex_raw, .-print_hex_raw
+	addi	t2, t2, -1 
+	andi	t0, a0, 0x0f
+	# digit < 10?
+	sltiu	t3, t0, 10
+	bnez	t3, print_hex_new_decimal
+	addi	t0, t0, 39
+print_hex_new_decimal:	  
+	addi	t0, t0, 48
+	sb		t0, 0(t2)						# to buffer
+	srli	a0, a0, 4						# next nibble
+	bnez	a0, print_hex_new_next_nibble	# only if more to come
+	# print buffer
+	mv		a0, t2
+	jal		print_string
+	LOAD_X	ra, 0(sp)			  
+	addi	sp, sp, (XLEN_BYTES*1)
+	ret
+	.size print_hex_raw, .-print_hex_raw
 
 
-# print a 2-digit hex value (with leading zero for 1-digit values)
-# in: byte value in a0
+	# print a 2-digit hex value (with leading zero for 1-digit values)
+	# in: byte value in a0
 print_hex_byte:
-    addi    sp, sp, -(XLEN_BYTES*2)             
-    SAVE_X  ra, 0(sp)
-    SAVE_X  s1, (XLEN_BYTES*1)(sp)
-    li      t0, 15
-    bgt     a0, t0, print_hex_byte_two_digits
-    # print a leading zero if necessary
-    mv      s1, a0                  # save a0 for later
-    li      a0, '0'
-    jal     print_char
-    mv      a0, s1                  # restore a0
+	addi	sp, sp, -(XLEN_BYTES*2)				
+	SAVE_X	ra, 0(sp)
+	SAVE_X	s1, (XLEN_BYTES*1)(sp)
+	li		t0, 15
+	bgt		a0, t0, print_hex_byte_two_digits
+	# print a leading zero if necessary
+	mv		s1, a0					# save a0 for later
+	li		a0, '0'
+	jal		print_char
+	mv		a0, s1					# restore a0
 print_hex_byte_two_digits:
-    jal     print_hex_raw
-    LOAD_X  ra, 0(sp)             
-    LOAD_X  s1, (XLEN_BYTES*1)(sp)
-    addi    sp, sp, (XLEN_BYTES*2)
-    ret
-.size print_hex_byte, .-print_hex_byte
+	jal		print_hex_raw
+	LOAD_X	ra, 0(sp)			  
+	LOAD_X	s1, (XLEN_BYTES*1)(sp)
+	addi	sp, sp, (XLEN_BYTES*2)
+	ret
+	.size print_hex_byte, .-print_hex_byte
 
 
-# print char in a0 to terminal (if printable, else '.')
+	# print char in a0 to terminal (if printable, else '.')
 print_ascii:
-    addi    sp, sp, -(XLEN_BYTES*1)             
-    SAVE_X  ra, 0(sp)
-    # consider only chars from 0x20-0x7e as printable
-    li      t0, 0x20
-    blt     a0, t0, print_ascii_substitute
-    li      t0, 0x7e
-    bgt     a0, t0, print_ascii_substitute
-    j       print_ascii_out         # char is printable
+	addi	sp, sp, -(XLEN_BYTES*1)				
+	SAVE_X	ra, 0(sp)
+	# consider only chars from 0x20-0x7e as printable
+	li		t0, 0x20
+	blt		a0, t0, print_ascii_substitute
+	li		t0, 0x7e
+	bgt		a0, t0, print_ascii_substitute
+	j		print_ascii_out			# char is printable
 print_ascii_substitute:
-    li      a0, '.'                 # print dot if char is not printable
+	li		a0, '.'					# print dot if char is not printable
 print_ascii_out:
-    jal     print_char
-    LOAD_X  ra, 0(sp)             
-    addi    sp, sp, (XLEN_BYTES*1)
-    ret
-.size print_ascii, .-print_ascii
+	jal		print_char
+	LOAD_X	ra, 0(sp)			  
+	addi	sp, sp, (XLEN_BYTES*1)
+	ret
+	.size print_ascii, .-print_ascii
 
 
-# print ASCII char in a0
+	# print ASCII char in a0
 print_char:
-    j       uart_output_char
-.size print_char, .-print_char
+	j		uart_output_char
+	.size print_char, .-print_char
 
 
-# print string starting at addr in a0
+	# print string starting at addr in a0
 print_string:
-    j       uart_output_string
-.size print_string, .-print_string
+	j		uart_output_string
+	.size print_string, .-print_string
 
 
-#ifdef WITH_CMD_D
+	#ifdef WITH_CMD_D
 
-# print 32-bit signed decimal in a0 to terminal
+	# print 32-bit signed decimal in a0 to terminal
 print_decimal:
-    addi    sp, sp, -(XLEN_BYTES*2)           
-    SAVE_X  ra, 0(sp)
-    SAVE_X  s2, (XLEN_BYTES*1)(sp)
-    beqz    a0, print_decimal_zero
-    # save a0
-    mv      t6, a0
-    # terminate buffer at the end
-    la      s2, dec_buf
-    addi    s2, s2, (DEC_BUFFER_SIZE-1)
-    sb      zero, 0(s2)
-    # invert if negative
-    bgtz    t6, print_decimal_skip_invert
-    neg     a0, a0
+	addi	sp, sp, -(XLEN_BYTES*2)			  
+	SAVE_X	ra, 0(sp)
+	SAVE_X	s2, (XLEN_BYTES*1)(sp)
+	beqz	a0, print_decimal_zero
+	# save a0
+	mv		t6, a0
+	# terminate buffer at the end
+	la		s2, dec_buf
+	addi	s2, s2, (DEC_BUFFER_SIZE-1)
+	sb		zero, 0(s2)
+	# invert if negative
+	bgtz	t6, print_decimal_skip_invert
+	neg		a0, a0
 print_decimal_skip_invert:
-    # write ASCII digits to buffer backward starting at the end
+	# write ASCII digits to buffer backward starting at the end
 print_decimal_loop:
-    # dec buffer ptr
-    addi    s2, s2, -1
-    li      a1, 10
-    # a0 = quotient, a1 = divisor
-    jal     divrem
-    # output digit as ASCII to buffer
-    addi    t0, a1, 48
-    sb      t0, 0(s2)
-    # repeat
-    bnez    a0, print_decimal_loop   
-    # print minus if negative
-    bgtz    t6, print_decimal_skip_minus
-    li      a0, '-'
-    jal     print_char
+	# dec buffer ptr
+	addi	s2, s2, -1
+	li		a1, 10
+	# a0 = quotient, a1 = divisor
+	jal		divrem
+	# output digit as ASCII to buffer
+	addi	t0, a1, 48
+	sb		t0, 0(s2)
+	# repeat
+	bnez	a0, print_decimal_loop	 
+	# print minus if negative
+	bgtz	t6, print_decimal_skip_minus
+	li		a0, '-'
+	jal		print_char
 print_decimal_skip_minus:
-    # output buffer, starting at last written location
-    mv      a0, s2
-    jal     print_string
-    j       print_decimal_done
+	# output buffer, starting at last written location
+	mv		a0, s2
+	jal		print_string
+	j		print_decimal_done
 print_decimal_zero:
-    li      a0, '0'
-    jal     print_char
+	li		a0, '0'
+	jal		print_char
 print_decimal_done:
-    LOAD_X  ra, 0(sp)             
-    LOAD_X  s2, (XLEN_BYTES*1)(sp)               
-    addi    sp, sp, (XLEN_BYTES*2)
-    ret
-.size print_decimal, .-print_decimal
+	LOAD_X	ra, 0(sp)			  
+	LOAD_X	s2, (XLEN_BYTES*1)(sp)				 
+	addi	sp, sp, (XLEN_BYTES*2)
+	ret
+	.size print_decimal, .-print_decimal
 
 
-#endif /* WITH_CMD_D */
+	#endif /* WITH_CMD_D */
 
-.data
+	.data
 
-.align 8
+	.align 8
 
-#ifdef WITH_CMD_D
-.comm dec_buf, DEC_BUFFER_SIZE
-.size dec_buf, DEC_BUFFER_SIZE
-#endif /* WITH_CMD_D */
+	#ifdef WITH_CMD_D
+	.comm dec_buf, DEC_BUFFER_SIZE
+	.size dec_buf, DEC_BUFFER_SIZE
+	#endif /* WITH_CMD_D */
 
 
-.comm out_buf, OUT_BUFFER_SIZE
-.size out_buf, OUT_BUFFER_SIZE
+	.comm out_buf, OUT_BUFFER_SIZE
+	.size out_buf, OUT_BUFFER_SIZE
 

--- a/src/testcode.S
+++ b/src/testcode.S
@@ -1,850 +1,850 @@
-#include "vmon/config.h"
+	#include "vmon/config.h"
 
-#ifdef WITH_TESTCODE
+	#ifdef WITH_TESTCODE
 
-.global testcode
-.global testcode_RV32I
-.global testcode_RV64I
-.global testcode_RVM
-.global testcode_RVA
-.global testcode_RVF
-.global testcode_RVD
-.global testcode_RVQ
-.global testcode_RVC
-.global testcode_RVV
-.global testcode_RVZicsr
-.global testcode_RVZifencei
-.global testcode_RVPRIV
-.global testcode_PSEUDO
+	.global testcode
+	.global testcode_RV32I
+	.global testcode_RV64I
+	.global testcode_RVM
+	.global testcode_RVA
+	.global testcode_RVF
+	.global testcode_RVD
+	.global testcode_RVQ
+	.global testcode_RVC
+	.global testcode_RVV
+	.global testcode_RVZicsr
+	.global testcode_RVZifencei
+	.global testcode_RVPRIV
+	.global testcode_PSEUDO
 
 
-.text
+	.text
 
 
 testcode:
 
-#ifdef WITH_TESTCODE_RV32I
-.option push
-.option norvc
+	#ifdef WITH_TESTCODE_RV32I
+	.option push
+	.option norvc
 testcode_RV32I:
-    ret
-    nop
-    ecall
-    ebreak  
-    fence   i, i   
-    fence   o, o   
-    fence   r, r   
-    fence   w, w   
-    fence   io, io
-    fence   rw, rw   
-    fence   iorw, iorw
-    fence.tso
-    add     x0, x0, x0
-    add     x31, x31, x31
-    sub     x0, x0, x0
-    sub     x31, x31, x31
-    xor     x0, x0, x0
-    xor     x31, x31, x31
-    or      x0, x0, x0
-    or      x31, x31, x31
-    and     x0, x0, x0
-    and     x31, x31, x31
-    sll     x0, x0, x0
-    sll     x31, x31, x31
-    srl     x0, x0, x0
-    srl     x31, x31, x31
-    sra     x0, x0, x0
-    sra     x31, x31, x31
-    slt     x0, x0, x0
-    slt     x31, x31, x31
-    sltu    x0, x0, x0
-    sltu    x31, x31, x31
-    addi    x0, x0, 0
-    addi    x31, x31, 0
-    addi    x0, x0, 2047
-    addi    x31, x31, 2047
-    addi    x0, x0, -2048
-    addi    x31, x31, -2048
-    xori    x0, x0, 0
-    xori    x31, x31, 0
-    xori    x0, x0, 2047
-    xori    x31, x31, 2047
-    xori    x0, x0, -2048
-    xori    x31, x31, -2048
-    ori     x0, x0, 0
-    ori     x31, x31, 0
-    ori     x0, x0, 2047
-    ori     x31, x31, 2047
-    ori     x0, x0, -2048
-    ori     x31, x31, -2048
-    andi    x0, x0, 0
-    andi    x31, x31, 0
-    andi    x0, x0, 2047
-    andi    x31, x31, 2047
-    andi    x0, x0, -2048
-    andi    x31, x31, -2048
-    slli    x0, x0, 0x0
-    slli    x31, x31, 0x0
-    slli    x0, x0, 0x1f
-    slli    x31, x31, 0x1f
-    srli    x0, x0, 0x0
-    srli    x31, x31, 0x0
-    srli    x0, x0, 0x1f
-    srli    x31, x31, 0x1f
-    srai    x0, x0, 0x0
-    srai    x31, x31, 0x0
-    srai    x0, x0, 0x1f
-    srai    x31, x31, 0x1f
-    slti    x0, x0, 0x0
-    slti    x31, x31, 0x0
-    slti    x0, x0, 0x1f
-    slti    x31, x31, 0x1f
-    slti    x0, x0, 0x3f
-    slti    x31, x31, 0x3f
-    sltiu   x0, x0, 0x0
-    sltiu   x31, x31, 0x0
-    sltiu   x0, x0, 0x1f
-    sltiu   x31, x31, 0x1f
-    sltiu   x0, x0, 0x3f
-    sltiu   x31, x31, 0x3f
-    lb      x0, 0(x0) #0x0
-    lb      x0, 2047(x0) #0x7ff
-    lb      x0, -2048(x0) #0xfffffffffffff800   
-    lh      x31, 0(x31)
-    lh      x31, 2047(x31)
-    lh      x31, -2048(x31)
-    lw      x0, 0(x0)
-    lw      x0, 2047(x0)
-    lw      x0, -2048(x0)
-    lbu     x31, 0(x31)
-    lbu     x31, 2047(x31)
-    lbu     x31, -2048(x31)
-    lhu     x31, 0(x31)
-    lhu     x31, 2047(x31)
-    lhu     x31, -2048(x31)
-    sb      x0, 0(x0)
-    sb      x0, 2047(x0)
-    sb      x0, -2048(x0)
-    sh      x31, 0(x31)
-    sh      x31, 2047(x31)
-    sh      x31, -2048(x31)
-    sw      x0, 0(x0)
-    sw      x0, 2047(x0)
-    sw      x0, -2048(x0)
+	ret
+	nop
+	ecall
+	ebreak	
+	fence	i, i   
+	fence	o, o   
+	fence	r, r   
+	fence	w, w   
+	fence	io, io
+	fence	rw, rw	 
+	fence	iorw, iorw
+	fence.tso
+	add		x0, x0, x0
+	add		x31, x31, x31
+	sub		x0, x0, x0
+	sub		x31, x31, x31
+	xor		x0, x0, x0
+	xor		x31, x31, x31
+	or		x0, x0, x0
+	or		x31, x31, x31
+	and		x0, x0, x0
+	and		x31, x31, x31
+	sll		x0, x0, x0
+	sll		x31, x31, x31
+	srl		x0, x0, x0
+	srl		x31, x31, x31
+	sra		x0, x0, x0
+	sra		x31, x31, x31
+	slt		x0, x0, x0
+	slt		x31, x31, x31
+	sltu	x0, x0, x0
+	sltu	x31, x31, x31
+	addi	x0, x0, 0
+	addi	x31, x31, 0
+	addi	x0, x0, 2047
+	addi	x31, x31, 2047
+	addi	x0, x0, -2048
+	addi	x31, x31, -2048
+	xori	x0, x0, 0
+	xori	x31, x31, 0
+	xori	x0, x0, 2047
+	xori	x31, x31, 2047
+	xori	x0, x0, -2048
+	xori	x31, x31, -2048
+	ori		x0, x0, 0
+	ori		x31, x31, 0
+	ori		x0, x0, 2047
+	ori		x31, x31, 2047
+	ori		x0, x0, -2048
+	ori		x31, x31, -2048
+	andi	x0, x0, 0
+	andi	x31, x31, 0
+	andi	x0, x0, 2047
+	andi	x31, x31, 2047
+	andi	x0, x0, -2048
+	andi	x31, x31, -2048
+	slli	x0, x0, 0x0
+	slli	x31, x31, 0x0
+	slli	x0, x0, 0x1f
+	slli	x31, x31, 0x1f
+	srli	x0, x0, 0x0
+	srli	x31, x31, 0x0
+	srli	x0, x0, 0x1f
+	srli	x31, x31, 0x1f
+	srai	x0, x0, 0x0
+	srai	x31, x31, 0x0
+	srai	x0, x0, 0x1f
+	srai	x31, x31, 0x1f
+	slti	x0, x0, 0x0
+	slti	x31, x31, 0x0
+	slti	x0, x0, 0x1f
+	slti	x31, x31, 0x1f
+	slti	x0, x0, 0x3f
+	slti	x31, x31, 0x3f
+	sltiu	x0, x0, 0x0
+	sltiu	x31, x31, 0x0
+	sltiu	x0, x0, 0x1f
+	sltiu	x31, x31, 0x1f
+	sltiu	x0, x0, 0x3f
+	sltiu	x31, x31, 0x3f
+	lb		x0, 0(x0) #0x0
+	lb		x0, 2047(x0) #0x7ff
+	lb		x0, -2048(x0) #0xfffffffffffff800	
+	lh		x31, 0(x31)
+	lh		x31, 2047(x31)
+	lh		x31, -2048(x31)
+	lw		x0, 0(x0)
+	lw		x0, 2047(x0)
+	lw		x0, -2048(x0)
+	lbu		x31, 0(x31)
+	lbu		x31, 2047(x31)
+	lbu		x31, -2048(x31)
+	lhu		x31, 0(x31)
+	lhu		x31, 2047(x31)
+	lhu		x31, -2048(x31)
+	sb		x0, 0(x0)
+	sb		x0, 2047(x0)
+	sb		x0, -2048(x0)
+	sh		x31, 0(x31)
+	sh		x31, 2047(x31)
+	sh		x31, -2048(x31)
+	sw		x0, 0(x0)
+	sw		x0, 2047(x0)
+	sw		x0, -2048(x0)
 testcode_branch_backward:
-    beq     zero, zero, testcode_branch_backward
-    beq     zero, zero, testcode_branch_forward
-    bne     zero, zero, testcode_branch_backward
-    bne     zero, zero, testcode_branch_forward
-    blt     zero, zero, testcode_branch_backward
-    blt     zero, zero, testcode_branch_forward
-    bge     zero, zero, testcode_branch_backward
-    bge     zero, zero, testcode_branch_forward
-    bltu    zero, zero, testcode_branch_backward
-    bltu    zero, zero, testcode_branch_forward
-    bgeu    zero, zero, testcode_branch_backward
-    bgeu    zero, zero, testcode_branch_forward
+	beq		zero, zero, testcode_branch_backward
+	beq		zero, zero, testcode_branch_forward
+	bne		zero, zero, testcode_branch_backward
+	bne		zero, zero, testcode_branch_forward
+	blt		zero, zero, testcode_branch_backward
+	blt		zero, zero, testcode_branch_forward
+	bge		zero, zero, testcode_branch_backward
+	bge		zero, zero, testcode_branch_forward
+	bltu	zero, zero, testcode_branch_backward
+	bltu	zero, zero, testcode_branch_forward
+	bgeu	zero, zero, testcode_branch_backward
+	bgeu	zero, zero, testcode_branch_forward
 testcode_branch_forward: 
 testcode_jal_backward:
-    jal     x0, testcode_jal_backward
-    jal     x0, testcode_jal_forward
-    jal     x31, testcode_jal_backward
-    jal     x31, testcode_jal_forward
-    jalr    x0, 2047
-    jalr    x0, -2048
-    jalr    x31, 2047
-    jalr    x31, -2048
+	jal		x0, testcode_jal_backward
+	jal		x0, testcode_jal_forward
+	jal		x31, testcode_jal_backward
+	jal		x31, testcode_jal_forward
+	jalr	x0, 2047
+	jalr	x0, -2048
+	jalr	x31, 2047
+	jalr	x31, -2048
 testcode_jal_forward:
-    lui     x0, 0
-    lui     x0, 31
-    lui     x0, 1048575
-    auipc   x0, 0
-    auipc   x0, 31
-    auipc   x0, 1048575
-.option pop /* norvc */
-.size testcode_RV32I, .-testcode_RV32I
-#endif /* WITH_TESTCODE_RV32I */
+	lui		x0, 0
+	lui		x0, 31
+	lui		x0, 1048575
+	auipc	x0, 0
+	auipc	x0, 31
+	auipc	x0, 1048575
+	.option pop /* norvc */
+	.size testcode_RV32I, .-testcode_RV32I
+	#endif /* WITH_TESTCODE_RV32I */
 
 
-# RV64I
-#if defined(WITH_TESTCODE_RV64I) && (XLEN >= 64)
-.option push
-.option norvc
+	# RV64I
+	#if defined(WITH_TESTCODE_RV64I) && (XLEN >= 64)
+	.option push
+	.option norvc
 testcode_RV64I:
-    lwu     x0, 0(x0)
-    lwu     x0, 2047(x0)
-    lwu     x0, -2048(x0)
-    lwu     x31, 0(x0)
-    lwu     x31, 2047(x0)
-    lwu     x31, -2048(x0)
-    ld      x0, 0(x0)
-    ld      x0, 2047(x0)
-    ld      x0, -2048(x0)
-    ld      x31, 0(x0)
-    ld      x31, 2047(x0)
-    ld      x31, -2048(x0)
-    sd      x0, 0(x0)
-    sd      x0, 2047(x0)
-    sd      x0, -2048(x0)
-    sd      x31, 0(x0)
-    sd      x31, 2047(x0)
-    sd      x31, -2048(x0)
-    addiw   x0, x0, 0
-    addiw   x31, x31, 0
-    addiw   x0, x0, 31
-    addiw   x31, x31, 31
-    addiw   x0, x0, 63
-    addiw   x31, x31, 63
-    srliw   x0, x0, 0
-    srliw   x31, x31, 0
-    srliw   x0, x0, 31
-    srliw   x31, x31, 31
-    srli    x0, x0, 0x3f
-    srli    x31, x31, 0x3f
-    slliw   x0, x0, 0
-    slliw   x31, x31, 0
-    slliw   x0, x0, 31
-    slliw   x31, x31, 31
-    slli    x0, x0, 0x3f
-    slli    x31, x31, 0x3f
-    sraiw   x0, x0, 0
-    sraiw   x31, x31, 0
-    sraiw   x0, x0, 31
-    sraiw   x31, x31, 31
-    srai    x0, x0, 0x3f
-    srai    x31, x31, 0x3f
-    addw    x0, x0, 0
-    addw    x31, x31, 0
-    addw    x0, x0, 31
-    addw    x31, x31, 31
-    subw    x0, x0, x0
-    subw    x0, x0, x31
-    subw    x31, x31, x0
-    subw    x31, x31, x31
-    srlw    x0, x0, 0
-    srlw    x31, x31, 0
-    srlw    x0, x0, 31
-    srlw    x31, x31, 31
-    sllw    x0, x0, 0
-    sllw    x31, x31, 0
-    sllw    x0, x0, 31
-    sllw    x31, x31, 31
-    sraw    x0, x0, 0
-    sraw    x31, x31, 0
-    sraw    x0, x0, 31
-    sraw    x31, x31, 31
-.option pop /* norvc */
-.size testcode_RV64I, .-testcode_RV64I
-#endif /* WITH_TESTCODE_RV32I */
+	lwu		x0, 0(x0)
+	lwu		x0, 2047(x0)
+	lwu		x0, -2048(x0)
+	lwu		x31, 0(x0)
+	lwu		x31, 2047(x0)
+	lwu		x31, -2048(x0)
+	ld		x0, 0(x0)
+	ld		x0, 2047(x0)
+	ld		x0, -2048(x0)
+	ld		x31, 0(x0)
+	ld		x31, 2047(x0)
+	ld		x31, -2048(x0)
+	sd		x0, 0(x0)
+	sd		x0, 2047(x0)
+	sd		x0, -2048(x0)
+	sd		x31, 0(x0)
+	sd		x31, 2047(x0)
+	sd		x31, -2048(x0)
+	addiw	x0, x0, 0
+	addiw	x31, x31, 0
+	addiw	x0, x0, 31
+	addiw	x31, x31, 31
+	addiw	x0, x0, 63
+	addiw	x31, x31, 63
+	srliw	x0, x0, 0
+	srliw	x31, x31, 0
+	srliw	x0, x0, 31
+	srliw	x31, x31, 31
+	srli	x0, x0, 0x3f
+	srli	x31, x31, 0x3f
+	slliw	x0, x0, 0
+	slliw	x31, x31, 0
+	slliw	x0, x0, 31
+	slliw	x31, x31, 31
+	slli	x0, x0, 0x3f
+	slli	x31, x31, 0x3f
+	sraiw	x0, x0, 0
+	sraiw	x31, x31, 0
+	sraiw	x0, x0, 31
+	sraiw	x31, x31, 31
+	srai	x0, x0, 0x3f
+	srai	x31, x31, 0x3f
+	addw	x0, x0, 0
+	addw	x31, x31, 0
+	addw	x0, x0, 31
+	addw	x31, x31, 31
+	subw	x0, x0, x0
+	subw	x0, x0, x31
+	subw	x31, x31, x0
+	subw	x31, x31, x31
+	srlw	x0, x0, 0
+	srlw	x31, x31, 0
+	srlw	x0, x0, 31
+	srlw	x31, x31, 31
+	sllw	x0, x0, 0
+	sllw	x31, x31, 0
+	sllw	x0, x0, 31
+	sllw	x31, x31, 31
+	sraw	x0, x0, 0
+	sraw	x31, x31, 0
+	sraw	x0, x0, 31
+	sraw	x31, x31, 31
+	.option pop /* norvc */
+	.size testcode_RV64I, .-testcode_RV64I
+	#endif /* WITH_TESTCODE_RV32I */
 
 
-#ifdef WITH_TESTCODE_RVM
-.option push
-.option norvc
+	#ifdef WITH_TESTCODE_RVM
+	.option push
+	.option norvc
 testcode_RVM:
-    # RV32M
-    mul     x0, x1, x2
-    mul     x29, x30, x31
-    mulh    x0, x1, x2
-    mulh    x29, x30, x31
-    mulhu   x0, x1, x2
-    mulhu   x29, x30, x31
-    mulhsu  x0, x1, x2
-    mulhsu  x29, x30, x31
-    div     x0, x1, x2
-    div     x29, x30, x31
-    divu    x0, x1, x2
-    divu    x29, x30, x31
-    rem     x0, x1, x2
-    rem     x29, x30, x31
-    remu    x0, x1, x2
-    remu    x29, x30, x31
-    # RV64M
-    #if XLEN >= 64 
-        mulw     x0, x1, x2
-        mulw     x29, x30, x31
-        divw     x0, x1, x2
-        divw     x29, x30, x31
-        remw     x0, x1, x2
-        remw     x29, x30, x31
-        remuw    x0, x1, x2
-        remuw    x29, x30, x31
-    #endif
-.option pop /* norvc */
-.size testcode_RVM, .-testcode_RVM
-#endif /* WITH_TESTCODE_RVM */
+	# RV32M
+	mul		x0, x1, x2
+	mul		x29, x30, x31
+	mulh	x0, x1, x2
+	mulh	x29, x30, x31
+	mulhu	x0, x1, x2
+	mulhu	x29, x30, x31
+	mulhsu	x0, x1, x2
+	mulhsu	x29, x30, x31
+	div		x0, x1, x2
+	div		x29, x30, x31
+	divu	x0, x1, x2
+	divu	x29, x30, x31
+	rem		x0, x1, x2
+	rem		x29, x30, x31
+	remu	x0, x1, x2
+	remu	x29, x30, x31
+	# RV64M
+	#if XLEN >= 64 
+	mulw	 x0, x1, x2
+	mulw	 x29, x30, x31
+	divw	 x0, x1, x2
+	divw	 x29, x30, x31
+	remw	 x0, x1, x2
+	remw	 x29, x30, x31
+	remuw	 x0, x1, x2
+	remuw	 x29, x30, x31
+	#endif
+	.option pop /* norvc */
+	.size testcode_RVM, .-testcode_RVM
+	#endif /* WITH_TESTCODE_RVM */
 
 
-#ifdef WITH_TESTCODE_RVA
-.option push
-.option norvc
+	#ifdef WITH_TESTCODE_RVA
+	.option push
+	.option norvc
 testcode_RVA:
-    # RV32A
-    lr.w            x0, (x1)
-    lr.w            x30, (x31)
-    lr.w.aq         x0, (x1)
-    lr.w.aq         x30, (x31)
-    lr.w.rl         x0, (x1)
-    lr.w.rl         x30, (x31)
-    lr.w.aqrl       x0, (x1)
-    lr.w.aqrl       x30, (x31)
-    sc.w            x0, x1, (x2)
-    sc.w            x29, x30, (x31)
-    sc.w.aq         x0, x0, (x0)
-    sc.w.aq         x31, x31, (x31)
-    sc.w.rl         x0, x0, (x0)
-    sc.w.rl         x31, x31, (x31)
-    sc.w.aqrl       x0, x0, (x0)
-    sc.w.aqrl       x31, x31, (x31)
-    amoswap.w       x0, x0, (x0)
-    amoswap.w       x31, x31, (x31)
-    amoswap.w.aq    x0, x0, (x0)
-    amoswap.w.aq    x31, x31, (x31)
-    amoswap.w.rl    x0, x0, (x0)
-    amoswap.w.rl    x31, x31, (x31)
-    amoswap.w.aqrl  x0, x0, (x0)
-    amoswap.w.aqrl  x31, x31, (x31)
-    amoadd.w        x0, x0, (x0)
-    amoadd.w        x31, x31, (x31)
-    amoadd.w.aq     x0, x0, (x0)
-    amoadd.w.aq     x31, x31, (x31)
-    amoadd.w.rl     x0, x0, (x0)
-    amoadd.w.rl     x31, x31, (x31)
-    amoadd.w.aqrl   x0, x0, (x0)
-    amoadd.w.aqrl   x31, x31, (x31)
-    amoxor.w        x0, x0, (x0)
-    amoxor.w        x31, x31, (x31)
-    amoxor.w.aq     x0, x0, (x0)
-    amoxor.w.aq     x31, x31, (x31)
-    amoxor.w.rl     x0, x0, (x0)
-    amoxor.w.rl     x31, x31, (x31)
-    amoxor.w.aqrl   x0, x0, (x0)
-    amoxor.w.aqrl   x31, x31, (x31)
-    amoand.w        x0, x0, (x0)
-    amoand.w        x31, x31, (x31)
-    amoand.w.aq     x0, x0, (x0)
-    amoand.w.aq     x31, x31, (x31)
-    amoand.w.rl     x0, x0, (x0)
-    amoand.w.rl     x31, x31, (x31)
-    amoand.w.aqrl   x0, x0, (x0)
-    amoand.w.aqrl   x31, x31, (x31)
-    amoor.w         x0, x0, (x0)
-    amoor.w         x31, x31, (x31)
-    amoor.w.aq      x0, x0, (x0)
-    amoor.w.aq      x31, x31, (x31)
-    amoor.w.rl      x0, x0, (x0)
-    amoor.w.rl      x31, x31, (x31)
-    amoor.w.aqrl    x0, x0, (x0)
-    amoor.w.aqrl    x31, x31, (x31)
-    amomin.w        x0, x0, (x0)
-    amomin.w        x31, x31, (x31)
-    amomin.w.aq     x0, x0, (x0)
-    amomin.w.aq     x31, x31, (x31)
-    amomin.w.rl     x0, x0, (x0)
-    amomin.w.rl     x31, x31, (x31)
-    amomin.w.aqrl   x0, x0, (x0)
-    amomin.w.aqrl   x31, x31, (x31)
-    amomax.w        x0, x0, (x0)
-    amomax.w        x31, x31, (x31)
-    amomax.w.aq     x0, x0, (x0)
-    amomax.w.aq     x31, x31, (x31)
-    amomax.w.rl     x0, x0, (x0)
-    amomax.w.rl     x31, x31, (x31)
-    amomax.w.aqrl   x0, x0, (x0)
-    amomax.w.aqrl   x31, x31, (x31)
-    amominu.w       x0, x0, (x0)
-    amominu.w       x31, x31, (x31)
-    amominu.w.aq    x0, x0, (x0)
-    amominu.w.aq    x31, x31, (x31)
-    amominu.w.rl    x0, x0, (x0)
-    amominu.w.rl    x31, x31, (x31)
-    amominu.w.aqrl  x0, x0, (x0)
-    amominu.w.aqrl  x31, x31, (x31)
-    amomaxu.w       x0, x0, (x0)
-    amomaxu.w       x31, x31, (x31)
-    amomaxu.w.aq    x0, x0, (x0)
-    amomaxu.w.aq    x31, x31, (x31)
-    amomaxu.w.rl    x0, x0, (x0)
-    amomaxu.w.rl    x31, x31, (x31)
-    amomaxu.w.aqrl  x0, x0, (x0)
-    amomaxu.w.aqrl  x31, x31, (x31)
-    # RV64A
-    #if XLEN >= 64
-        lr.d            x0, (x1)
-        lr.d            x30, (x31)
-        lr.d.aq         x0, (x1)
-        lr.d.aq         x30, (x31)
-        lr.d.rl         x0, (x1)
-        lr.d.rl         x30, (x31)
-        lr.d.aqrl       x0, (x1)
-        lr.d.aqrl       x30, (x31)
-        sc.d            x0, x0, (x0)
-        sc.d            x31, x31, (x31)
-        sc.d.aq         x0, x0, (x0)
-        sc.d.aq         x31, x31, (x31)
-        sc.d.rl         x0, x0, (x0)
-        sc.d.rl         x31, x31, (x31)
-        sc.d.aqrl       x0, x0, (x0)
-        sc.d.aqrl       x31, x31, (x31)
-        amoswap.d       x0, x0, (x0)
-        amoswap.d       x31, x31, (x31)
-        amoswap.d.aq    x0, x0, (x0)
-        amoswap.d.aq    x31, x31, (x31)
-        amoswap.d.rl    x0, x0, (x0)
-        amoswap.d.rl    x31, x31, (x31)
-        amoswap.d.aqrl  x0, x0, (x0)
-        amoswap.d.aqrl  x31, x31, (x31)
-        amoadd.d        x0, x0, (x0)
-        amoadd.d        x31, x31, (x31)
-        amoadd.d.aq     x0, x0, (x0)
-        amoadd.d.aq     x31, x31, (x31)
-        amoadd.d.rl     x0, x0, (x0)
-        amoadd.d.rl     x31, x31, (x31)
-        amoadd.d.aqrl   x0, x0, (x0)
-        amoadd.d.aqrl   x31, x31, (x31)
-        amoxor.d        x0, x0, (x0)
-        amoxor.d        x31, x31, (x31)
-        amoxor.d.aq     x0, x0, (x0)
-        amoxor.d.aq     x31, x31, (x31)
-        amoxor.d.rl     x0, x0, (x0)
-        amoxor.d.rl     x31, x31, (x31)
-        amoxor.d.aqrl   x0, x0, (x0)
-        amoxor.d.aqrl   x31, x31, (x31)
-        amoand.d        x0, x0, (x0)
-        amoand.d        x31, x31, (x31)
-        amoand.d.aq     x0, x0, (x0)
-        amoand.d.aq     x31, x31, (x31)
-        amoand.d.rl     x0, x0, (x0)
-        amoand.d.rl     x31, x31, (x31)
-        amoand.d.aqrl   x0, x0, (x0)
-        amoand.d.aqrl   x31, x31, (x31)
-        amoor.d         x0, x0, (x0)
-        amoor.d         x31, x31, (x31)
-        amoor.d.aq      x0, x0, (x0)
-        amoor.d.aq      x31, x31, (x31)
-        amoor.d.rl      x0, x0, (x0)
-        amoor.d.rl      x31, x31, (x31)
-        amoor.d.aqrl    x0, x0, (x0)
-        amoor.d.aqrl    x31, x31, (x31)
-        amomin.d        x0, x0, (x0)
-        amomin.d        x31, x31, (x31)
-        amomin.d.aq     x0, x0, (x0)
-        amomin.d.aq     x31, x31, (x31)
-        amomin.d.rl     x0, x0, (x0)
-        amomin.d.rl     x31, x31, (x31)
-        amomin.d.aqrl   x0, x0, (x0)
-        amomin.d.aqrl   x31, x31, (x31)
-        amomax.d        x0, x0, (x0)
-        amomax.d        x31, x31, (x31)
-        amomax.d.aq     x0, x0, (x0)
-        amomax.d.aq     x31, x31, (x31)
-        amomax.d.rl     x0, x0, (x0)
-        amomax.d.rl     x31, x31, (x31)
-        amomax.d.aqrl   x0, x0, (x0)
-        amomax.d.aqrl   x31, x31, (x31)
-        amominu.d       x0, x0, (x0)
-        amominu.d       x31, x31, (x31)
-        amominu.d.aq    x0, x0, (x0)
-        amominu.d.aq    x31, x31, (x31)
-        amominu.d.rl    x0, x0, (x0)
-        amominu.d.rl    x31, x31, (x31)
-        amominu.d.aqrl  x0, x0, (x0)
-        amominu.d.aqrl  x31, x31, (x31)
-        amomaxu.d       x0, x0, (x0)
-        amomaxu.d       x31, x31, (x31)
-        amomaxu.d.aq    x0, x0, (x0)
-        amomaxu.d.aq    x31, x31, (x31)
-        amomaxu.d.rl    x0, x0, (x0)
-        amomaxu.d.rl    x31, x31, (x31)
-        amomaxu.d.aqrl  x0, x0, (x0)
-        amomaxu.d.aqrl  x31, x31, (x31)
-    #endif
-.option pop /* norvc */
-.size testcode_RVA, .-testcode_RVA
-#endif /* WITH_TESTCODE_RVA */
+	# RV32A
+	lr.w			x0, (x1)
+	lr.w			x30, (x31)
+	lr.w.aq			x0, (x1)
+	lr.w.aq			x30, (x31)
+	lr.w.rl			x0, (x1)
+	lr.w.rl			x30, (x31)
+	lr.w.aqrl		x0, (x1)
+	lr.w.aqrl		x30, (x31)
+	sc.w			x0, x1, (x2)
+	sc.w			x29, x30, (x31)
+	sc.w.aq			x0, x0, (x0)
+	sc.w.aq			x31, x31, (x31)
+	sc.w.rl			x0, x0, (x0)
+	sc.w.rl			x31, x31, (x31)
+	sc.w.aqrl		x0, x0, (x0)
+	sc.w.aqrl		x31, x31, (x31)
+	amoswap.w		x0, x0, (x0)
+	amoswap.w		x31, x31, (x31)
+	amoswap.w.aq	x0, x0, (x0)
+	amoswap.w.aq	x31, x31, (x31)
+	amoswap.w.rl	x0, x0, (x0)
+	amoswap.w.rl	x31, x31, (x31)
+	amoswap.w.aqrl	x0, x0, (x0)
+	amoswap.w.aqrl	x31, x31, (x31)
+	amoadd.w		x0, x0, (x0)
+	amoadd.w		x31, x31, (x31)
+	amoadd.w.aq		x0, x0, (x0)
+	amoadd.w.aq		x31, x31, (x31)
+	amoadd.w.rl		x0, x0, (x0)
+	amoadd.w.rl		x31, x31, (x31)
+	amoadd.w.aqrl	x0, x0, (x0)
+	amoadd.w.aqrl	x31, x31, (x31)
+	amoxor.w		x0, x0, (x0)
+	amoxor.w		x31, x31, (x31)
+	amoxor.w.aq		x0, x0, (x0)
+	amoxor.w.aq		x31, x31, (x31)
+	amoxor.w.rl		x0, x0, (x0)
+	amoxor.w.rl		x31, x31, (x31)
+	amoxor.w.aqrl	x0, x0, (x0)
+	amoxor.w.aqrl	x31, x31, (x31)
+	amoand.w		x0, x0, (x0)
+	amoand.w		x31, x31, (x31)
+	amoand.w.aq		x0, x0, (x0)
+	amoand.w.aq		x31, x31, (x31)
+	amoand.w.rl		x0, x0, (x0)
+	amoand.w.rl		x31, x31, (x31)
+	amoand.w.aqrl	x0, x0, (x0)
+	amoand.w.aqrl	x31, x31, (x31)
+	amoor.w			x0, x0, (x0)
+	amoor.w			x31, x31, (x31)
+	amoor.w.aq		x0, x0, (x0)
+	amoor.w.aq		x31, x31, (x31)
+	amoor.w.rl		x0, x0, (x0)
+	amoor.w.rl		x31, x31, (x31)
+	amoor.w.aqrl	x0, x0, (x0)
+	amoor.w.aqrl	x31, x31, (x31)
+	amomin.w		x0, x0, (x0)
+	amomin.w		x31, x31, (x31)
+	amomin.w.aq		x0, x0, (x0)
+	amomin.w.aq		x31, x31, (x31)
+	amomin.w.rl		x0, x0, (x0)
+	amomin.w.rl		x31, x31, (x31)
+	amomin.w.aqrl	x0, x0, (x0)
+	amomin.w.aqrl	x31, x31, (x31)
+	amomax.w		x0, x0, (x0)
+	amomax.w		x31, x31, (x31)
+	amomax.w.aq		x0, x0, (x0)
+	amomax.w.aq		x31, x31, (x31)
+	amomax.w.rl		x0, x0, (x0)
+	amomax.w.rl		x31, x31, (x31)
+	amomax.w.aqrl	x0, x0, (x0)
+	amomax.w.aqrl	x31, x31, (x31)
+	amominu.w		x0, x0, (x0)
+	amominu.w		x31, x31, (x31)
+	amominu.w.aq	x0, x0, (x0)
+	amominu.w.aq	x31, x31, (x31)
+	amominu.w.rl	x0, x0, (x0)
+	amominu.w.rl	x31, x31, (x31)
+	amominu.w.aqrl	x0, x0, (x0)
+	amominu.w.aqrl	x31, x31, (x31)
+	amomaxu.w		x0, x0, (x0)
+	amomaxu.w		x31, x31, (x31)
+	amomaxu.w.aq	x0, x0, (x0)
+	amomaxu.w.aq	x31, x31, (x31)
+	amomaxu.w.rl	x0, x0, (x0)
+	amomaxu.w.rl	x31, x31, (x31)
+	amomaxu.w.aqrl	x0, x0, (x0)
+	amomaxu.w.aqrl	x31, x31, (x31)
+	# RV64A
+	#if XLEN >= 64
+	lr.d			x0, (x1)
+	lr.d			x30, (x31)
+	lr.d.aq			x0, (x1)
+	lr.d.aq			x30, (x31)
+	lr.d.rl			x0, (x1)
+	lr.d.rl			x30, (x31)
+	lr.d.aqrl		x0, (x1)
+	lr.d.aqrl		x30, (x31)
+	sc.d			x0, x0, (x0)
+	sc.d			x31, x31, (x31)
+	sc.d.aq			x0, x0, (x0)
+	sc.d.aq			x31, x31, (x31)
+	sc.d.rl			x0, x0, (x0)
+	sc.d.rl			x31, x31, (x31)
+	sc.d.aqrl		x0, x0, (x0)
+	sc.d.aqrl		x31, x31, (x31)
+	amoswap.d		x0, x0, (x0)
+	amoswap.d		x31, x31, (x31)
+	amoswap.d.aq	x0, x0, (x0)
+	amoswap.d.aq	x31, x31, (x31)
+	amoswap.d.rl	x0, x0, (x0)
+	amoswap.d.rl	x31, x31, (x31)
+	amoswap.d.aqrl	x0, x0, (x0)
+	amoswap.d.aqrl	x31, x31, (x31)
+	amoadd.d		x0, x0, (x0)
+	amoadd.d		x31, x31, (x31)
+	amoadd.d.aq		x0, x0, (x0)
+	amoadd.d.aq		x31, x31, (x31)
+	amoadd.d.rl		x0, x0, (x0)
+	amoadd.d.rl		x31, x31, (x31)
+	amoadd.d.aqrl	x0, x0, (x0)
+	amoadd.d.aqrl	x31, x31, (x31)
+	amoxor.d		x0, x0, (x0)
+	amoxor.d		x31, x31, (x31)
+	amoxor.d.aq		x0, x0, (x0)
+	amoxor.d.aq		x31, x31, (x31)
+	amoxor.d.rl		x0, x0, (x0)
+	amoxor.d.rl		x31, x31, (x31)
+	amoxor.d.aqrl	x0, x0, (x0)
+	amoxor.d.aqrl	x31, x31, (x31)
+	amoand.d		x0, x0, (x0)
+	amoand.d		x31, x31, (x31)
+	amoand.d.aq		x0, x0, (x0)
+	amoand.d.aq		x31, x31, (x31)
+	amoand.d.rl		x0, x0, (x0)
+	amoand.d.rl		x31, x31, (x31)
+	amoand.d.aqrl	x0, x0, (x0)
+	amoand.d.aqrl	x31, x31, (x31)
+	amoor.d			x0, x0, (x0)
+	amoor.d			x31, x31, (x31)
+	amoor.d.aq		x0, x0, (x0)
+	amoor.d.aq		x31, x31, (x31)
+	amoor.d.rl		x0, x0, (x0)
+	amoor.d.rl		x31, x31, (x31)
+	amoor.d.aqrl	x0, x0, (x0)
+	amoor.d.aqrl	x31, x31, (x31)
+	amomin.d		x0, x0, (x0)
+	amomin.d		x31, x31, (x31)
+	amomin.d.aq		x0, x0, (x0)
+	amomin.d.aq		x31, x31, (x31)
+	amomin.d.rl		x0, x0, (x0)
+	amomin.d.rl		x31, x31, (x31)
+	amomin.d.aqrl	x0, x0, (x0)
+	amomin.d.aqrl	x31, x31, (x31)
+	amomax.d		x0, x0, (x0)
+	amomax.d		x31, x31, (x31)
+	amomax.d.aq		x0, x0, (x0)
+	amomax.d.aq		x31, x31, (x31)
+	amomax.d.rl		x0, x0, (x0)
+	amomax.d.rl		x31, x31, (x31)
+	amomax.d.aqrl	x0, x0, (x0)
+	amomax.d.aqrl	x31, x31, (x31)
+	amominu.d		x0, x0, (x0)
+	amominu.d		x31, x31, (x31)
+	amominu.d.aq	x0, x0, (x0)
+	amominu.d.aq	x31, x31, (x31)
+	amominu.d.rl	x0, x0, (x0)
+	amominu.d.rl	x31, x31, (x31)
+	amominu.d.aqrl	x0, x0, (x0)
+	amominu.d.aqrl	x31, x31, (x31)
+	amomaxu.d		x0, x0, (x0)
+	amomaxu.d		x31, x31, (x31)
+	amomaxu.d.aq	x0, x0, (x0)
+	amomaxu.d.aq	x31, x31, (x31)
+	amomaxu.d.rl	x0, x0, (x0)
+	amomaxu.d.rl	x31, x31, (x31)
+	amomaxu.d.aqrl	x0, x0, (x0)
+	amomaxu.d.aqrl	x31, x31, (x31)
+	#endif
+	.option pop /* norvc */
+	.size testcode_RVA, .-testcode_RVA
+	#endif /* WITH_TESTCODE_RVA */
 
 
-#ifdef WITH_TESTCODE_RVF
+	#ifdef WITH_TESTCODE_RVF
 testcode_RVF:
-.option push
-.option norvc
-    flw         f0, 0(x0)
-    flw         f31, 0(x31)
-    flw         f0, 2047(x0)
-    flw         f31, -2048(x31)
-    fsw         f0, 0(x0)
-    fsw         f31, 0(x31)
-    fsw         f0, 2047(x0)
-    fsw         f31, -2048(x31)
-    fmadd.s     f0, f1, f2, f3
-    fmadd.s     f28, f29, f30, f31
-    fmsub.s     f0, f1, f2, f3
-    fmsub.s     f28, f29, f30, f31
-    fnmadd.s    f0, f1, f2, f3
-    fnmadd.s    f28, f29, f30, f31
-    fnmsub.s    f0, f1, f2, f3
-    fnmsub.s    f28, f29, f30, f31
-    fadd.s      f0, f1, f2
-    fadd.s      f29, f30, f31
-    fsub.s      f0, f1, f2
-    fsub.s      f29, f30, f31
-    fmul.s      f0, f1, f2
-    fmul.s      f29, f30, f31
-    fdiv.s      f0, f1, f2
-    fdiv.s      f29, f30, f31
-    fsqrt.s     f0, f0    
-    fsqrt.s     f31, f31
-    fsgnj.s     f0, f1, f2 
-    fsgnj.s     f29, f30, f31 
-    fsgnjn.s    f0, f1, f2 
-    fsgnjn.s    f29, f30, f31 
-    fsgnjx.s    f0, f1, f2 
-    fsgnjx.s    f29, f30, f31
-    fmin.s      f0, f1, f2 
-    fmin.s      f29, f30, f31 
-    fmax.s      f0, f1, f2 
-    fmax.s      f29, f30, f31 
-    fcvt.s.w    f0, x0 
-    fcvt.s.w    f31, x31 
-    fcvt.s.wu   f0, x0 
-    fcvt.s.wu   f31, x31 
-    fcvt.w.s    x0, f0
-    fcvt.w.s    x31, f31 
-    fcvt.wu.s   x0, f0 
-    fcvt.wu.s   x31, f31 
-    fmv.x.w     x0, f0 
-    fmv.x.w     x31, f31 
-    fmv.w.x     f0, x0 
-    fmv.w.x     f31, x31 
-    feq.s       x0, f1, f2     
-    feq.s       x31, f30, f31     
-    flt.s       x0, f1, f2     
-    flt.s       x31, f30, f31     
-    fle.s       x0, f1, f2     
-    fle.s       x31, f30, f31     
-    fclass.s    x0, f0   
-    fclass.s    x31, f31   
-.option pop /* norvc */
-.size testcode_RVF, .-testcode_RVF
-#endif /* WITH_TESTCODE_RVF */
+	.option push
+	.option norvc
+	flw			f0, 0(x0)
+	flw			f31, 0(x31)
+	flw			f0, 2047(x0)
+	flw			f31, -2048(x31)
+	fsw			f0, 0(x0)
+	fsw			f31, 0(x31)
+	fsw			f0, 2047(x0)
+	fsw			f31, -2048(x31)
+	fmadd.s		f0, f1, f2, f3
+	fmadd.s		f28, f29, f30, f31
+	fmsub.s		f0, f1, f2, f3
+	fmsub.s		f28, f29, f30, f31
+	fnmadd.s	f0, f1, f2, f3
+	fnmadd.s	f28, f29, f30, f31
+	fnmsub.s	f0, f1, f2, f3
+	fnmsub.s	f28, f29, f30, f31
+	fadd.s		f0, f1, f2
+	fadd.s		f29, f30, f31
+	fsub.s		f0, f1, f2
+	fsub.s		f29, f30, f31
+	fmul.s		f0, f1, f2
+	fmul.s		f29, f30, f31
+	fdiv.s		f0, f1, f2
+	fdiv.s		f29, f30, f31
+	fsqrt.s		f0, f0	  
+	fsqrt.s		f31, f31
+	fsgnj.s		f0, f1, f2 
+	fsgnj.s		f29, f30, f31 
+	fsgnjn.s	f0, f1, f2 
+	fsgnjn.s	f29, f30, f31 
+	fsgnjx.s	f0, f1, f2 
+	fsgnjx.s	f29, f30, f31
+	fmin.s		f0, f1, f2 
+	fmin.s		f29, f30, f31 
+	fmax.s		f0, f1, f2 
+	fmax.s		f29, f30, f31 
+	fcvt.s.w	f0, x0 
+	fcvt.s.w	f31, x31 
+	fcvt.s.wu	f0, x0 
+	fcvt.s.wu	f31, x31 
+	fcvt.w.s	x0, f0
+	fcvt.w.s	x31, f31 
+	fcvt.wu.s	x0, f0 
+	fcvt.wu.s	x31, f31 
+	fmv.x.w		x0, f0 
+	fmv.x.w		x31, f31 
+	fmv.w.x		f0, x0 
+	fmv.w.x		f31, x31 
+	feq.s		x0, f1, f2	   
+	feq.s		x31, f30, f31	  
+	flt.s		x0, f1, f2	   
+	flt.s		x31, f30, f31	  
+	fle.s		x0, f1, f2	   
+	fle.s		x31, f30, f31	  
+	fclass.s	x0, f0	 
+	fclass.s	x31, f31   
+	.option pop /* norvc */
+	.size testcode_RVF, .-testcode_RVF
+	#endif /* WITH_TESTCODE_RVF */
 
 
-#if defined (WITH_TESTCODE_RVD) && XLEN >= 64
+	#if defined (WITH_TESTCODE_RVD) && XLEN >= 64
 testcode_RVD:
-.option push
-.option norvc
-    fld         f0, 0(x0)
-    fld         f31, 0(x31)
-    fld         f0, 2047(x0)
-    fld         f31, -2048(x31)
-    fsd         f0, 0(x0)
-    fsd         f31, 0(x31)
-    fsd         f0, 2047(x0)
-    fsd         f31, -2048(x31)
-    fmadd.d     f0, f1, f2, f3
-    fmadd.d     f28, f29, f30, f31
-    fmsub.d     f0, f1, f2, f3
-    fmsub.d     f28, f29, f30, f31
-    fnmadd.d    f0, f1, f2, f3
-    fnmadd.d    f28, f29, f30, f31
-    fnmsub.d    f0, f1, f2, f3
-    fnmsub.d    f28, f29, f30, f31
-    fadd.d      f0, f1, f2
-    fadd.d      f29, f30, f31
-    fsub.d      f0, f1, f2
-    fsub.d      f29, f30, f31
-    fmul.d      f0, f1, f2
-    fmul.d      f29, f30, f31
-    fdiv.d      f0, f1, f2
-    fdiv.d      f29, f30, f31
-    fsqrt.d     f0, f0    
-    fsqrt.d     f31, f31
-    fsgnj.d     f0, f1, f2 
-    fsgnj.d     f29, f20, f31 
-    fsgnjn.d    f0, f1, f2 
-    fsgnjn.d    f29, f20, f31 
-    fsgnjx.d    f0, f1, f2 
-    fsgnjx.d    f29, f20, f31
-    fmin.d      f0, f1, f2 
-    fmin.d      f29, f20, f31 
-    fmax.d      f0, f1, f2 
-    fmax.d      f29, f20, f31 
-    fcvt.d.w    f0, x0 
-    fcvt.d.w    f31, x31 
-    fcvt.d.wu   f0, x0 
-    fcvt.d.wu   f31, x31 
-    fcvt.w.d    x0, f0
-    fcvt.w.d    x31, f31 
-    fcvt.wu.d   x0, f0 
-    fcvt.wu.d   x31, f31 
-    fmv.x.d     x0, f0 
-    fmv.x.d     x31, f31 
-    fmv.d.x     f0, x0 
-    fmv.d.x     f31, x31 
-    feq.d       x0, f1, f2     
-    feq.d       x31, f30, f31     
-    flt.d       x0, f1, f2     
-    flt.d       x31, f30, f31     
-    fle.d       x0, f1, f2     
-    fle.d       x31, f30, f31     
-    fclass.d    x0, f0   
-    fclass.d    x31, f31   
-.option pop /* norvc */
-.size testcode_RVD, .-testcode_RVD
-#endif /* WITH_TESTCODE_RVD */
+	.option push
+	.option norvc
+	fld			f0, 0(x0)
+	fld			f31, 0(x31)
+	fld			f0, 2047(x0)
+	fld			f31, -2048(x31)
+	fsd			f0, 0(x0)
+	fsd			f31, 0(x31)
+	fsd			f0, 2047(x0)
+	fsd			f31, -2048(x31)
+	fmadd.d		f0, f1, f2, f3
+	fmadd.d		f28, f29, f30, f31
+	fmsub.d		f0, f1, f2, f3
+	fmsub.d		f28, f29, f30, f31
+	fnmadd.d	f0, f1, f2, f3
+	fnmadd.d	f28, f29, f30, f31
+	fnmsub.d	f0, f1, f2, f3
+	fnmsub.d	f28, f29, f30, f31
+	fadd.d		f0, f1, f2
+	fadd.d		f29, f30, f31
+	fsub.d		f0, f1, f2
+	fsub.d		f29, f30, f31
+	fmul.d		f0, f1, f2
+	fmul.d		f29, f30, f31
+	fdiv.d		f0, f1, f2
+	fdiv.d		f29, f30, f31
+	fsqrt.d		f0, f0	  
+	fsqrt.d		f31, f31
+	fsgnj.d		f0, f1, f2 
+	fsgnj.d		f29, f20, f31 
+	fsgnjn.d	f0, f1, f2 
+	fsgnjn.d	f29, f20, f31 
+	fsgnjx.d	f0, f1, f2 
+	fsgnjx.d	f29, f20, f31
+	fmin.d		f0, f1, f2 
+	fmin.d		f29, f20, f31 
+	fmax.d		f0, f1, f2 
+	fmax.d		f29, f20, f31 
+	fcvt.d.w	f0, x0 
+	fcvt.d.w	f31, x31 
+	fcvt.d.wu	f0, x0 
+	fcvt.d.wu	f31, x31 
+	fcvt.w.d	x0, f0
+	fcvt.w.d	x31, f31 
+	fcvt.wu.d	x0, f0 
+	fcvt.wu.d	x31, f31 
+	fmv.x.d		x0, f0 
+	fmv.x.d		x31, f31 
+	fmv.d.x		f0, x0 
+	fmv.d.x		f31, x31 
+	feq.d		x0, f1, f2	   
+	feq.d		x31, f30, f31	  
+	flt.d		x0, f1, f2	   
+	flt.d		x31, f30, f31	  
+	fle.d		x0, f1, f2	   
+	fle.d		x31, f30, f31	  
+	fclass.d	x0, f0	 
+	fclass.d	x31, f31   
+	.option pop /* norvc */
+	.size testcode_RVD, .-testcode_RVD
+	#endif /* WITH_TESTCODE_RVD */
 
 
-#if defined (WITH_TESTCODE_RVQ) && XLEN >= 128
+	#if defined (WITH_TESTCODE_RVQ) && XLEN >= 128
 testcode_RVQ:
-.option push
-.option norvc
-    flq         f0, 0(x0)
-    flq         f31, 0(x31)
-    flq         f0, 2047(x0)
-    flq         f31, -2048(x31)
-    fsq         f0, 0(x0)
-    fsq         f31, 0(x31)
-    fsq         f0, 2047(x0)
-    fsq         f31, -2048(x31)
-    fmadd.q     f0, f1, f2, f3
-    fmadd.q     f28, f29, f30, f31
-    fmsub.q     f0, f1, f2, f3
-    fmsub.q     f28, f29, f30, f31
-    fnmadd.q    f0, f1, f2, f3
-    fnmadd.q    f28, f29, f30, f31
-    fnmsub.q    f0, f1, f2, f3
-    fnmsub.q    f28, f29, f30, f31
-    fadd.q      f0, f1, f2
-    fadd.q      f29, f30, f31
-    fsub.q      f0, f1, f2
-    fsub.q      f29, f30, f31
-    fmul.q      f0, f1, f2
-    fmul.q      f29, f30, f31
-    fdiv.q      f0, f1, f2
-    fdiv.q      f29, f30, f31
-    fsqrt.q     f0, f0    
-    fsqrt.q     f31, f31
-    fsgnj.q     f0, f1, f2 
-    fsgnj.q     f29, f20, f31 
-    fsgnjn.q    f0, f1, f2 
-    fsgnjn.q    f29, f20, f31 
-    fsgnjx.q    f0, f1, f2 
-    fsgnjx.q    f29, f20, f31
-    fmin.q      f0, f1, f2 
-    fmin.q      f29, f20, f31 
-    fmax.q      f0, f1, f2 
-    fmax.q      f29, f20, f31 
-    fcvt.q.w    f0, x0 
-    fcvt.q.w    f31, x31 
-    fcvt.q.wu   f0, x0 
-    fcvt.q.wu   f31, x31 
-    fcvt.w.q    x0, f0
-    fcvt.w.q    x31, f31 
-    fcvt.wu.q   x0, f0 
-    fcvt.wu.q   x31, f31 
-    fmv.x.q     x0, f0 
-    fmv.x.q     x31, f31 
-    fmv.q.x     f0, x0 
-    fmv.q.x     f31, x31 
-    feq.q       x0, f1, f2     
-    feq.q       x31, f30, f31     
-    flt.q       x0, f1, f2     
-    flt.q       x31, f30, f31     
-    fle.q       x0, f1, f2     
-    fle.q       x31, f30, f31     
-    fclass.q    x0, f0   
-    fclass.q    x31, f31   
-.option pop /* norvc */
-.size testcode_RVQ, .-testcode_RVQ
-#endif /* WITH_TESTCODE_RVQ */
+	.option push
+	.option norvc
+	flq			f0, 0(x0)
+	flq			f31, 0(x31)
+	flq			f0, 2047(x0)
+	flq			f31, -2048(x31)
+	fsq			f0, 0(x0)
+	fsq			f31, 0(x31)
+	fsq			f0, 2047(x0)
+	fsq			f31, -2048(x31)
+	fmadd.q		f0, f1, f2, f3
+	fmadd.q		f28, f29, f30, f31
+	fmsub.q		f0, f1, f2, f3
+	fmsub.q		f28, f29, f30, f31
+	fnmadd.q	f0, f1, f2, f3
+	fnmadd.q	f28, f29, f30, f31
+	fnmsub.q	f0, f1, f2, f3
+	fnmsub.q	f28, f29, f30, f31
+	fadd.q		f0, f1, f2
+	fadd.q		f29, f30, f31
+	fsub.q		f0, f1, f2
+	fsub.q		f29, f30, f31
+	fmul.q		f0, f1, f2
+	fmul.q		f29, f30, f31
+	fdiv.q		f0, f1, f2
+	fdiv.q		f29, f30, f31
+	fsqrt.q		f0, f0	  
+	fsqrt.q		f31, f31
+	fsgnj.q		f0, f1, f2 
+	fsgnj.q		f29, f20, f31 
+	fsgnjn.q	f0, f1, f2 
+	fsgnjn.q	f29, f20, f31 
+	fsgnjx.q	f0, f1, f2 
+	fsgnjx.q	f29, f20, f31
+	fmin.q		f0, f1, f2 
+	fmin.q		f29, f20, f31 
+	fmax.q		f0, f1, f2 
+	fmax.q		f29, f20, f31 
+	fcvt.q.w	f0, x0 
+	fcvt.q.w	f31, x31 
+	fcvt.q.wu	f0, x0 
+	fcvt.q.wu	f31, x31 
+	fcvt.w.q	x0, f0
+	fcvt.w.q	x31, f31 
+	fcvt.wu.q	x0, f0 
+	fcvt.wu.q	x31, f31 
+	fmv.x.q		x0, f0 
+	fmv.x.q		x31, f31 
+	fmv.q.x		f0, x0 
+	fmv.q.x		f31, x31 
+	feq.q		x0, f1, f2	   
+	feq.q		x31, f30, f31	  
+	flt.q		x0, f1, f2	   
+	flt.q		x31, f30, f31	  
+	fle.q		x0, f1, f2	   
+	fle.q		x31, f30, f31	  
+	fclass.q	x0, f0	 
+	fclass.q	x31, f31   
+	.option pop /* norvc */
+	.size testcode_RVQ, .-testcode_RVQ
+	#endif /* WITH_TESTCODE_RVQ */
 
 
-#if defined (WITH_TESTCODE_RVC) && defined (ENABLE_RVC)
+	#if defined (WITH_TESTCODE_RVC) && defined (ENABLE_RVC)
 testcode_RVC:
-    # CL_type
-    c.lw        x8, 0(x8)
-    c.lw        x8, 124(x8)
-    c.lw        x15, 124(x15)
-    # CS_type
-    c.sw        x8, 0(x8)
-    c.sw        x8, 124(x8)
-    c.sw        x15, 124(x15)
-    c.and       x8, x9
-    c.or        x8, x9
-    c.xor       x14, x15
-    c.sub       x14, x15
-    # CI_type
-    c.lwsp      x8, 0(sp)
-    c.lwsp      x15, 252(sp)
-    c.li        x1, 0
-    c.li        x1, 1
-    c.li        x31, 31
-    c.li        x31, -32
-    c.lui       x1, 1
-    c.lui       x1, 31
-    c.lui       x31, 1
-    c.lui       x31, 31
-    c.addi      x1, 0
-    c.addi      x1, 1
-    c.addi      x31, 31
-    c.addi      x31, -32
-    c.addi16sp  sp, 16
-    c.addi16sp  sp, -16
-    c.addi16sp  sp, 496
-    c.addi16sp  sp, -512
-    c.slli      x0, 1
-    c.slli      x31, 1
-    c.slli      x0, 31
-    c.slli      x31, 31
-    c.nop
-    # CSS_type
-    c.swsp      x8, 0(sp)
-    c.swsp      x15, 252(sp)
-    # CJ_type
-    c.j         testcode_RVC
-    # CR_type
-    c.jr        x1
-    c.jr        x31
-    c.jalr      x1
-    c.jalr      x31
-    c.mv        x1, x1
-    c.mv        x31, x31
-    c.add       x1, x1
-    c.add       x31, x31
-    c.ebreak
-    # CB_type
+	# CL_type
+	c.lw		x8, 0(x8)
+	c.lw		x8, 124(x8)
+	c.lw		x15, 124(x15)
+	# CS_type
+	c.sw		x8, 0(x8)
+	c.sw		x8, 124(x8)
+	c.sw		x15, 124(x15)
+	c.and		x8, x9
+	c.or		x8, x9
+	c.xor		x14, x15
+	c.sub		x14, x15
+	# CI_type
+	c.lwsp		x8, 0(sp)
+	c.lwsp		x15, 252(sp)
+	c.li		x1, 0
+	c.li		x1, 1
+	c.li		x31, 31
+	c.li		x31, -32
+	c.lui		x1, 1
+	c.lui		x1, 31
+	c.lui		x31, 1
+	c.lui		x31, 31
+	c.addi		x1, 0
+	c.addi		x1, 1
+	c.addi		x31, 31
+	c.addi		x31, -32
+	c.addi16sp	sp, 16
+	c.addi16sp	sp, -16
+	c.addi16sp	sp, 496
+	c.addi16sp	sp, -512
+	c.slli		x0, 1
+	c.slli		x31, 1
+	c.slli		x0, 31
+	c.slli		x31, 31
+	c.nop
+	# CSS_type
+	c.swsp		x8, 0(sp)
+	c.swsp		x15, 252(sp)
+	# CJ_type
+	c.j			testcode_RVC
+	# CR_type
+	c.jr		x1
+	c.jr		x31
+	c.jalr		x1
+	c.jalr		x31
+	c.mv		x1, x1
+	c.mv		x31, x31
+	c.add		x1, x1
+	c.add		x31, x31
+	c.ebreak
+	# CB_type
 testcode_RVC_CB_type_start:
-    c.beqz      x8, testcode_RVC_CB_type_start
-    c.beqz      x15, testcode_RVC_CB_type_start
-    c.bnez      x8, testcode_RVC_CB_type_end
-    c.bnez      x15, testcode_RVC_CB_type_end
-    c.srli      x8, 1
-    c.srli      x15, 31
-    c.srai      x8, 1
-    c.srai      x15, 31
-    c.andi      x8, 0
-    c.andi      x15, 31
-testcode_RVC_CB_type_end:   
-    #ifdef ENABLE_RVF
-        #c.flw       f8, 0(f8)
-        #c.fsw
-        #c.flwsp
-        #c.fswsp
-        #if XLEN >= 64
-            c.fld       f8, 0(x8)
-            c.fld       f15, 248(x15)
-            c.fsd       f8, 0(x8)
-            c.fsd       f15, 248(x15)
-            c.fldsp     f8, 0(sp)
-            c.fldsp     f15, 504(sp)
-            c.fsdsp     f8, 0(sp)
-            c.fsdsp     f15, 504(sp)
-        #endif
-    #endif /* ENABLE_RVF */
-    # RV32C only
-    #if XLEN == 32
-        c.jal       testcode_RVC
-    #endif
-    # RV64C
-    #if XLEN >= 64
-        c.ldsp      x8, 0(sp)
-        c.ldsp      x15, 496(sp)
-        c.sdsp      x8, 0(sp)
-        c.sdsp      x15, 496(sp)
-        c.ld        x8, 0(x8)
-        c.ld        x8, 248(x8)
-        c.ld        x15, 248(x15)
-        c.sd        x8, 0(x8)
-        c.sd        x8, 248(x8)
-        c.sd        x15, 248(x15)
-        c.addw      x8, x9
-        c.subw      x14, x15
-        c.addiw     x1, 0
-        c.addiw     x1, 1
-        c.addiw     x31, 31
-        c.addiw     x31, -32
-        c.slli      x0, 63
-        c.slli      x31, 63
-        c.srli      x15, 63
-        c.srai      x15, 63
-    #endif
-.size testcode_RVC, .-testcode_RVC
-#endif /* WITH_TESTCODE_RVC */
+	c.beqz		x8, testcode_RVC_CB_type_start
+	c.beqz		x15, testcode_RVC_CB_type_start
+	c.bnez		x8, testcode_RVC_CB_type_end
+	c.bnez		x15, testcode_RVC_CB_type_end
+	c.srli		x8, 1
+	c.srli		x15, 31
+	c.srai		x8, 1
+	c.srai		x15, 31
+	c.andi		x8, 0
+	c.andi		x15, 31
+testcode_RVC_CB_type_end:	
+	#ifdef ENABLE_RVF
+	#c.flw		 f8, 0(f8)
+	#c.fsw
+	#c.flwsp
+	#c.fswsp
+	#if XLEN >= 64
+	c.fld		f8, 0(x8)
+	c.fld		f15, 248(x15)
+	c.fsd		f8, 0(x8)
+	c.fsd		f15, 248(x15)
+	c.fldsp		f8, 0(sp)
+	c.fldsp		f15, 504(sp)
+	c.fsdsp		f8, 0(sp)
+	c.fsdsp		f15, 504(sp)
+	#endif
+	#endif /* ENABLE_RVF */
+	# RV32C only
+	#if XLEN == 32
+	c.jal		testcode_RVC
+	#endif
+	# RV64C
+	#if XLEN >= 64
+	c.ldsp		x8, 0(sp)
+	c.ldsp		x15, 496(sp)
+	c.sdsp		x8, 0(sp)
+	c.sdsp		x15, 496(sp)
+	c.ld		x8, 0(x8)
+	c.ld		x8, 248(x8)
+	c.ld		x15, 248(x15)
+	c.sd		x8, 0(x8)
+	c.sd		x8, 248(x8)
+	c.sd		x15, 248(x15)
+	c.addw		x8, x9
+	c.subw		x14, x15
+	c.addiw		x1, 0
+	c.addiw		x1, 1
+	c.addiw		x31, 31
+	c.addiw		x31, -32
+	c.slli		x0, 63
+	c.slli		x31, 63
+	c.srli		x15, 63
+	c.srai		x15, 63
+	#endif
+	.size testcode_RVC, .-testcode_RVC
+	#endif /* WITH_TESTCODE_RVC */
 
 
-#ifdef WITH_TESTCODE_RVV
-.option push
-.option norvc
+	#ifdef WITH_TESTCODE_RVV
+	.option push
+	.option norvc
 testcode_RVV:
-# TODO
-.option pop /* norvc */
-.size testcode_RVV, .-testcode_RVV
-#endif /* WITH_TESTCODE_RVV */
+	# TODO
+	.option pop /* norvc */
+	.size testcode_RVV, .-testcode_RVV
+	#endif /* WITH_TESTCODE_RVV */
 
 
-#ifdef WITH_TESTCODE_RVZicsr
-.option push
-.option norvc
+	#ifdef WITH_TESTCODE_RVZicsr
+	.option push
+	.option norvc
 testcode_RVZicsr:
-    csrrw   t1, 1, t2
-    csrrs   t3, cycle, t4
-    csrrc   t5, cycle, t6
-    csrrwi  t1, cycle, 0
-    csrrsi  t2, cycle, 0
-    csrrci  t3, cycle, 0
-    csrrwi  t4, cycle, 31
-    csrrsi  t5, cycle, 31
-    csrrci  t6, cycle, 31
-    csrrw   t1, 1, t2
-    csrrs   t3, cycle, t4
-    csrrc   t5, cycle, t6
-    csrrwi  t1, cycle, 0
-    csrrsi  t2, cycle, 0
-    csrrci  t3, cycle, 0
-    csrrwi  t4, cycle, 31
-    csrrsi  t5, cycle, 31
-    csrrci  t6, cycle, 31
-.option pop /* norvc */
-.size testcode_RVZicsr, .-testcode_RVZicsr
-#endif /* WITH_TESTCODE_RVZicsr */
+	csrrw	t1, 1, t2
+	csrrs	t3, cycle, t4
+	csrrc	t5, cycle, t6
+	csrrwi	t1, cycle, 0
+	csrrsi	t2, cycle, 0
+	csrrci	t3, cycle, 0
+	csrrwi	t4, cycle, 31
+	csrrsi	t5, cycle, 31
+	csrrci	t6, cycle, 31
+	csrrw	t1, 1, t2
+	csrrs	t3, cycle, t4
+	csrrc	t5, cycle, t6
+	csrrwi	t1, cycle, 0
+	csrrsi	t2, cycle, 0
+	csrrci	t3, cycle, 0
+	csrrwi	t4, cycle, 31
+	csrrsi	t5, cycle, 31
+	csrrci	t6, cycle, 31
+	.option pop /* norvc */
+	.size testcode_RVZicsr, .-testcode_RVZicsr
+	#endif /* WITH_TESTCODE_RVZicsr */
 
 
-#ifdef WITH_TESTCODE_RVZifencei
-.option push
-.option norvc
+	#ifdef WITH_TESTCODE_RVZifencei
+	.option push
+	.option norvc
 testcode_RVZifencei:
-    fence.i
-.option pop /* norvc */
-.size testcode_RVZifencei, .-testcode_RVZifencei
-#endif /* WITH_TESTCODE_RVZifencei */
+	fence.i
+	.option pop /* norvc */
+	.size testcode_RVZifencei, .-testcode_RVZifencei
+	#endif /* WITH_TESTCODE_RVZifencei */
 
 
-#ifdef WITH_TESTCODE_RVPRIV
-.option push
-.option norvc
+	#ifdef WITH_TESTCODE_RVPRIV
+	.option push
+	.option norvc
 testcode_RVPRIV:
-    sret
-    mret
-    wfi
-    sfence.vm
-    sfence.vma
-.option pop /* norvc */
-.size testcode_RVPRIV, .-testcode_RVPRIV
-#endif /* WITH_TESTCODE_RVPRIV */
+	sret
+	mret
+	wfi
+	sfence.vm
+	sfence.vma
+	.option pop /* norvc */
+	.size testcode_RVPRIV, .-testcode_RVPRIV
+	#endif /* WITH_TESTCODE_RVPRIV */
 
 
-#ifdef WITH_TESTCODE_PSEUDO
-.option push
-.option norvc
+	#ifdef WITH_TESTCODE_PSEUDO
+	.option push
+	.option norvc
 testcode_PSEUDO:
-    jalr    x0, x1, 0           # ret
-    ret
-    addi    x0, x0, 0           # nop
-    nop
-.option pop /* norvc */
-.size testcode_PSEUDO, .-testcode_PSEUDO
-#endif /* WITH_TESTCODE_PSEUDO */
+	jalr	x0, x1, 0			# ret
+	ret
+	addi	x0, x0, 0			# nop
+	nop
+	.option pop /* norvc */
+	.size testcode_PSEUDO, .-testcode_PSEUDO
+	#endif /* WITH_TESTCODE_PSEUDO */
 
 
-.size testcode, .-testcode
-#endif /* WITH_TESTCODE */
+	.size testcode, .-testcode
+	#endif /* WITH_TESTCODE */

--- a/src/trap.S
+++ b/src/trap.S
@@ -1,14 +1,14 @@
-#include "vmon/config.h"
+	#include "vmon/config.h"
 
-#ifdef BARE_METAL
+	#ifdef BARE_METAL
 
-.global setup_trap_handler
+	.global setup_trap_handler
 
-#define TIMER_INTERVAL 10000000
+	#define TIMER_INTERVAL 10000000
 
-#define MTIMECMP 0x2004000			# QEMU CLINT 0x2000000 + 0x4000 + 8*(hart_id)
+	#define MTIMECMP 0x2004000			# QEMU CLINT 0x2000000 + 0x4000 + 8*(hart_id)
 
-.text
+	.text
 
 
 setup_trap_handler:
@@ -18,7 +18,7 @@ setup_trap_handler:
 	# set up trap vector
 	la		t0, trap_handler
 	csrw	mtvec, t0
-/*
+	/*
 	# enable all m-mode irqs
 	csrsi	mstatus, 0b1000
 	# set timer for the first time
@@ -28,27 +28,27 @@ setup_trap_handler:
 	la		t2, MTIMECMP
 	sd		t1, 0(t2)
 	# enable m-mode timer irq
-	li 		t1, 0b10000000
-    csrs 	mie, t1
-*/
+	li		t1, 0b10000000
+	csrs	mie, t1
+	*/
 	ret
-.size setup_trap_handler, .-setup_trap_handler
+	.size setup_trap_handler, .-setup_trap_handler
 
 
-# trap handler needs to be aligned manually 
-# as that is not automatically guaranteed with RVC enabled
-.align 4
+	# trap handler needs to be aligned manually 
+	# as that is not automatically guaranteed with RVC enabled
+	.align 4
 
 trap_handler:
 	# push stack
-    addi    sp, sp, -(XLEN_BYTES*5)              
-    SAVE_X  ra, 0(sp)
-    SAVE_X  a0, (XLEN_BYTES*1)(sp)
-    SAVE_X  t0, (XLEN_BYTES*2)(sp)
-    SAVE_X  t1, (XLEN_BYTES*3)(sp)
-    SAVE_X  s0, (XLEN_BYTES*4)(sp)
+	addi	sp, sp, -(XLEN_BYTES*5)				 
+	SAVE_X	ra, 0(sp)
+	SAVE_X	a0, (XLEN_BYTES*1)(sp)
+	SAVE_X	t0, (XLEN_BYTES*2)(sp)
+	SAVE_X	t1, (XLEN_BYTES*3)(sp)
+	SAVE_X	s0, (XLEN_BYTES*4)(sp)
 	# clear irq
-	li 		t0, 0b10000000
+	li		t0, 0b10000000
 	csrc	mip, t0
 	# irq or exception? check leftmost bit of mcause
 	csrr	a0, mcause
@@ -84,7 +84,7 @@ trap_handler_exception:
 	mv		s0, a0								# save for later
 	jal		print_hex
 	# print MCAUSE verbose
-#ifdef MCAUSE_VERBOSE
+	#ifdef MCAUSE_VERBOSE
 	li		a0, ' '
 	jal		print_char
 	li		a0, '('
@@ -93,15 +93,15 @@ trap_handler_exception:
 	slli	a0, s0, 2							# set a0 = mcause * 4
 	la		s0, mcause_verbose_table			# start of MCAUSE string table
 	add		a0, a0, s0
-#if XLEN >= 64
+	#if XLEN >= 64
 	lwu		a0, 0(a0)
-#else
+	#else
 	lw		a0, 0(a0)
-#endif
-	jal 	print_string
+	#endif
+	jal		print_string
 	li		a0, ')'
 	jal		print_char
-#endif
+	#endif
 
 	# set return address for leaving trap handler
 	la		a0, main_prompt
@@ -121,24 +121,24 @@ trap_handler_irq:
 	SAVE_X	t1, 0(t0)
 trap_handler_pop:
 	# pop stack
-	LOAD_X  ra, 0(sp)
-	LOAD_X  a0, (XLEN_BYTES*1)(sp)
-	LOAD_X  t0, (XLEN_BYTES*2)(sp)
-	LOAD_X  t1, (XLEN_BYTES*3)(sp)
-	LOAD_X  s0, (XLEN_BYTES*4)(sp)
-	addi    sp, sp, (XLEN_BYTES*5)
+	LOAD_X	ra, 0(sp)
+	LOAD_X	a0, (XLEN_BYTES*1)(sp)
+	LOAD_X	t0, (XLEN_BYTES*2)(sp)
+	LOAD_X	t1, (XLEN_BYTES*3)(sp)
+	LOAD_X	s0, (XLEN_BYTES*4)(sp)
+	addi	sp, sp, (XLEN_BYTES*5)
 	mret
-.size trap_handler, .-trap_handler
+	.size trap_handler, .-trap_handler
 
 
-.data
+	.data
 
 string_exception_msg:		.string "\nexception:"
 string_mepc_msg:			.string "\n\tmepc\t= ";
 string_mtval_msg:			.string "\n\tmtval\t= ";
 string_mcause_msg:			.string "\n\tmcause\t= ";
 
-#ifdef MCAUSE_VERBOSE
+	#ifdef MCAUSE_VERBOSE
 string_CAUSE_MISALIGNED_FETCH:		.string "CAUSE_MISALIGNED_FETCH";
 string_CAUSE_FAULT_FETCH:			.string "CAUSE_FAULT_FETCH";
 string_CAUSE_ILLEGAL_INSTRUCTION:	.string "CAUSE_ILLEGAL_INSTRUCTION";
@@ -152,26 +152,26 @@ string_CAUSE_SUPERVISOR_ECALL:		.string "CAUSE_SUPERVISOR_ECALL";
 string_CAUSE_HYPERVISOR_ECALL:		.string "CAUSE_HYPERVISOR_ECALL";
 string_CAUSE_MACHINE_ECALL:			.string "CAUSE_MACHINE_ECALL";
 
-.align 4
+	.align 4
 mcause_verbose_table:
-.word string_CAUSE_MISALIGNED_FETCH
-.word string_CAUSE_FAULT_FETCH
-.word string_CAUSE_ILLEGAL_INSTRUCTION
-.word string_CAUSE_BREAKPOINT
-.word string_CAUSE_MISALIGNED_LOAD
-.word string_CAUSE_FAULT_LOAD
-.word string_CAUSE_MISALIGNED_STORE
-.word string_CAUSE_FAULT_STORE
-.word string_CAUSE_USER_ECALL
-.word string_CAUSE_SUPERVISOR_ECALL
-.word string_CAUSE_HYPERVISOR_ECALL
-.word string_CAUSE_MACHINE_ECALL
-#endif 
+	.word string_CAUSE_MISALIGNED_FETCH
+	.word string_CAUSE_FAULT_FETCH
+	.word string_CAUSE_ILLEGAL_INSTRUCTION
+	.word string_CAUSE_BREAKPOINT
+	.word string_CAUSE_MISALIGNED_LOAD
+	.word string_CAUSE_FAULT_LOAD
+	.word string_CAUSE_MISALIGNED_STORE
+	.word string_CAUSE_FAULT_STORE
+	.word string_CAUSE_USER_ECALL
+	.word string_CAUSE_SUPERVISOR_ECALL
+	.word string_CAUSE_HYPERVISOR_ECALL
+	.word string_CAUSE_MACHINE_ECALL
+	#endif 
 
 
-.bss
-.align 8
-.comm stackptr_reset, XLEN_BYTES
+	.bss
+	.align 8
+	.comm stackptr_reset, XLEN_BYTES
 
 
-#endif /* BARE_METAL */
+	#endif /* BARE_METAL */

--- a/src/uart.S
+++ b/src/uart.S
@@ -1,192 +1,192 @@
-#include "vmon/config.h"
-#include "vmon/drivers/uart/ns16550.h"
-#include "vmon/ASCII.h"
+	#include "vmon/config.h"
+	#include "vmon/drivers/uart/ns16550.h"
+	#include "vmon/ASCII.h"
 
 
 
-.global uart_init
-.global uart_wait_get_char
-.global uart_output_char
-.global uart_output_string
-.global uart_output_buffer
-.global uart_getline
+	.global uart_init
+	.global uart_wait_get_char
+	.global uart_output_char
+	.global uart_output_string
+	.global uart_output_buffer
+	.global uart_getline
 
-.text
+	.text
 
 uart_init:
-    li      t1, UART_BASE                  
-    li      t0, UART_MODE_8N1
-    sb      t0, UART_REG_LSR(t1)      
-    ret
-.size uart_init, .-uart_init
+	li		t1, UART_BASE				   
+	li		t0, UART_MODE_8N1
+	sb		t0, UART_REG_LSR(t1)	  
+	ret
+	.size uart_init, .-uart_init
 
 
 uart_clear_buffer:
-    la      t0, uart_input_buffer
-    addi    t1, t0, BUFFER_SIZE
+	la		t0, uart_input_buffer
+	addi	t1, t0, BUFFER_SIZE
 uart_clear_buffer_loop:
-    sw      zero, 0(t0)
-    addi    t0, t0, 4
-    ble     t0, t1, uart_clear_buffer_loop
-    ret
-.size uart_clear_buffer, .-uart_clear_buffer
+	sw		zero, 0(t0)
+	addi	t0, t0, 4
+	ble		t0, t1, uart_clear_buffer_loop
+	ret
+	.size uart_clear_buffer, .-uart_clear_buffer
 
 
-# wait and get one character from UART 
-# out: char (ASCII) in a0
+	# wait and get one character from UART 
+	# out: char (ASCII) in a0
 uart_wait_get_char:
-    li      t0, UART_BASE
+	li		t0, UART_BASE
 uart_get_char_wait:
-    # busy wait for key pressed
-    # TODO: use interrupt instead of polling
-    lb      a0, UART_REG_LSR(t0)        # read Line Status Register
-    and     a0, a0, 0x01
-    beqz    a0, uart_get_char_wait      # wait for char input
-    lbu     a0, 0(t0)                   # get input from UART  
-    ret
-.size uart_wait_get_char, .-uart_wait_get_char
+	# busy wait for key pressed
+	# TODO: use interrupt instead of polling
+	lb		a0, UART_REG_LSR(t0)		# read Line Status Register
+	and		a0, a0, 0x01
+	beqz	a0, uart_get_char_wait		# wait for char input
+	lbu		a0, 0(t0)					# get input from UART  
+	ret
+	.size uart_wait_get_char, .-uart_wait_get_char
 
 
-# output one char 
-# in: char (ASCII) in a0
+	# output one char 
+	# in: char (ASCII) in a0
 uart_output_char:
-    addi    sp, sp, -(XLEN_BYTES*1)             
-    SAVE_X  ra, 0(sp)
-    la      t0, out_buf  
-    andi    a0, a0, 0xff                # make sure value is < 256      
-    sh      a0, 0(t0)                   # write char and zero termination to buffer
-    jal     uart_output_buffer
-    LOAD_X  ra, 0(sp)             
-    addi    sp, sp, (XLEN_BYTES*1)
-    ret
-.size uart_output_char, .-uart_output_char
+	addi	sp, sp, -(XLEN_BYTES*1)				
+	SAVE_X	ra, 0(sp)
+	la		t0, out_buf	 
+	andi	a0, a0, 0xff				# make sure value is < 256		
+	sh		a0, 0(t0)					# write char and zero termination to buffer
+	jal		uart_output_buffer
+	LOAD_X	ra, 0(sp)			  
+	addi	sp, sp, (XLEN_BYTES*1)
+	ret
+	.size uart_output_char, .-uart_output_char
 
 
-# output zero-terminated string  
-# in: string ptr in a0
+	# output zero-terminated string	 
+	# in: string ptr in a0
 uart_output_string:
-    addi    sp, sp, -(XLEN_BYTES*1)             
-    SAVE_X  ra, 0(sp)
-    mv      a1, a0
+	addi	sp, sp, -(XLEN_BYTES*1)				
+	SAVE_X	ra, 0(sp)
+	mv		a1, a0
 uart_output_string_loop:
-    lb      a0, 0(a1)
-    beqz    a0, uart_output_string_done
-#ifdef USE_CRLF
-    li      t0, ASCII_NEWLINE
-    bne     a0, t0, uart_output_string_char
-    li      a0, ASCII_RETURN  # First output CR
-    jal     uart_output_char
-    li      a0, ASCII_NEWLINE # Put LF back in a0
+	lb		a0, 0(a1)
+	beqz	a0, uart_output_string_done
+	#ifdef USE_CRLF
+	li		t0, ASCII_NEWLINE
+	bne		a0, t0, uart_output_string_char
+	li		a0, ASCII_RETURN  # First output CR
+	jal		uart_output_char
+	li		a0, ASCII_NEWLINE # Put LF back in a0
 uart_output_string_char:
-#endif
-    jal     uart_output_char
-    addi    a1, a1, 1
-    j       uart_output_string_loop
+	#endif
+	jal		uart_output_char
+	addi	a1, a1, 1
+	j		uart_output_string_loop
 uart_output_string_done:
-    LOAD_X  ra, 0(sp)             
-    addi    sp, sp, (XLEN_BYTES*1)
-    ret
-.size uart_output_string, .-uart_output_string
+	LOAD_X	ra, 0(sp)			  
+	addi	sp, sp, (XLEN_BYTES*1)
+	ret
+	.size uart_output_string, .-uart_output_string
 
 
-# print zero-terminated string in output buffer out_buf to UART
-# buffer will be filled with zeros on return
+	# print zero-terminated string in output buffer out_buf to UART
+	# buffer will be filled with zeros on return
 uart_output_buffer:
-    addi    sp, sp, -(XLEN_BYTES*1)             
-    SAVE_X  ra, 0(sp)
-    la      t1, out_buf  
-    li      t4, UART_BASE
+	addi	sp, sp, -(XLEN_BYTES*1)				
+	SAVE_X	ra, 0(sp)
+	la		t1, out_buf	 
+	li		t4, UART_BASE
 uart_output_buffer_next_byte:
 	# TODO: output in blocks of x bytes? use FIFO?
-    lbu     t0, 0(t1)				    # get next byte from buffer
-	sb		zero, 0(t1)				    # clear buffer on the go
-    beq     t0, zero, uart_output_buffer_done
+	lbu		t0, 0(t1)					# get next byte from buffer
+	sb		zero, 0(t1)					# clear buffer on the go
+	beq		t0, zero, uart_output_buffer_done
 	# busy wait for UART to become ready
-    # TODO: use interrupts 
-    li      t2, UART_BASE  
+	# TODO: use interrupts 
+	li		t2, UART_BASE  
 uart_output_buffer_wait_lsr:
-    lbu     t3, UART_REG_LSR(t2)
-    andi    t3, t3, 0b00100000 
-    beqz    t3, uart_output_buffer_wait_lsr
-    # UART is now ready to receive data for TX
-    sb      t0, UART_REG_THR(t4)                   # print byte to UART
-    addi    t1, t1, 1
-    j       uart_output_buffer_next_byte
+	lbu		t3, UART_REG_LSR(t2)
+	andi	t3, t3, 0b00100000 
+	beqz	t3, uart_output_buffer_wait_lsr
+	# UART is now ready to receive data for TX
+	sb		t0, UART_REG_THR(t4)				   # print byte to UART
+	addi	t1, t1, 1
+	j		uart_output_buffer_next_byte
 uart_output_buffer_done:
-    LOAD_X  ra, 0(sp)             
-    addi    sp, sp, (XLEN_BYTES*1)
-    ret
-.size uart_output_buffer, .-uart_output_buffer
+	LOAD_X	ra, 0(sp)			  
+	addi	sp, sp, (XLEN_BYTES*1)
+	ret
+	.size uart_output_buffer, .-uart_output_buffer
 
 
-# get a line of input from UART until RETURN is hit
-# out: buffer start in a0
+	# get a line of input from UART until RETURN is hit
+	# out: buffer start in a0
 uart_getline:
-    addi    sp, sp, -(XLEN_BYTES*3)             
-    SAVE_X  ra, 0(sp)
-    SAVE_X  s0, (XLEN_BYTES*1)(sp)
-    SAVE_X  s1, (XLEN_BYTES*2)(sp)
+	addi	sp, sp, -(XLEN_BYTES*3)				
+	SAVE_X	ra, 0(sp)
+	SAVE_X	s0, (XLEN_BYTES*1)(sp)
+	SAVE_X	s1, (XLEN_BYTES*2)(sp)
 
-    jal     uart_clear_buffer
+	jal		uart_clear_buffer
 
-    la      s0, uart_input_buffer
-    mv      s1, s0                  # save a copy in s1 for later
+	la		s0, uart_input_buffer
+	mv		s1, s0					# save a copy in s1 for later
 uart_get_char:
-    jal     uart_wait_get_char
-    # is DELETE?
-    li      t0, ASCII_DELETE        
-    beq     a0, t0, uart_input_is_delete
-    # char is not DELETE
-    # check if end of input buffer is reached
-    la      t0, uart_input_buffer
-    addi    t0, t0, BUFFER_SIZE
-    # do not process input further when buffer is full
-    # (only possible user action when buffer is full will be to hit DELETE)
-    bge     s0, t0, uart_get_char
+	jal		uart_wait_get_char
+	# is DELETE?
+	li		t0, ASCII_DELETE		
+	beq		a0, t0, uart_input_is_delete
+	# char is not DELETE
+	# check if end of input buffer is reached
+	la		t0, uart_input_buffer
+	addi	t0, t0, BUFFER_SIZE
+	# do not process input further when buffer is full
+	# (only possible user action when buffer is full will be to hit DELETE)
+	bge		s0, t0, uart_get_char
 
-    sb      a0, 0(s0)               # store byte in input buffer
-    addi    s0, s0, 1               # inc buffer ptr
-    j       uart_continue_not_delete
+	sb		a0, 0(s0)				# store byte in input buffer
+	addi	s0, s0, 1				# inc buffer ptr
+	j		uart_continue_not_delete
 
 uart_input_is_delete:
-    # TODO: if the previous key transmitted more than 1 byte, this does 
-    # not work properly 
-    beq     s0, s1, uart_get_char        # ignore at beginning of line
-    addi    s0, s0, -1
-    # ASCII output
-    li      a0, ASCII_BACKSPACE
-    jal     uart_output_char
-    li      a0, ' '
-    jal     uart_output_char
-    li      a0, ASCII_BACKSPACE
-    jal     uart_output_char
-    j       uart_get_char  
+	# TODO: if the previous key transmitted more than 1 byte, this does 
+	# not work properly 
+	beq		s0, s1, uart_get_char		 # ignore at beginning of line
+	addi	s0, s0, -1
+	# ASCII output
+	li		a0, ASCII_BACKSPACE
+	jal		uart_output_char
+	li		a0, ' '
+	jal		uart_output_char
+	li		a0, ASCII_BACKSPACE
+	jal		uart_output_char
+	j		uart_get_char  
 
 uart_continue_not_delete:
-    # output char in a0
-    jal     uart_output_char
-    li      t0, ASCII_RETURN        
-    beq     a0, t0, uart_getline_done
-    j       uart_get_char      
+	# output char in a0
+	jal		uart_output_char
+	li		t0, ASCII_RETURN		
+	beq		a0, t0, uart_getline_done
+	j		uart_get_char	   
 
 uart_getline_done:
-    # print LF to follow read CR
-    li a0, ASCII_NEWLINE
-    jal uart_output_char
-    # return buffer address
-    mv      a0, s1
+	# print LF to follow read CR
+	li a0, ASCII_NEWLINE
+	jal uart_output_char
+	# return buffer address
+	mv		a0, s1
 
-    LOAD_X  ra, 0(sp)             
-    LOAD_X  s0, (XLEN_BYTES*1)(sp)               
-    LOAD_X  s1, (XLEN_BYTES*2)(sp)               
-    addi    sp, sp, (XLEN_BYTES*3)
-    ret
-.size uart_getline, .-uart_getline
+	LOAD_X	ra, 0(sp)			  
+	LOAD_X	s0, (XLEN_BYTES*1)(sp)				 
+	LOAD_X	s1, (XLEN_BYTES*2)(sp)				 
+	addi	sp, sp, (XLEN_BYTES*3)
+	ret
+	.size uart_getline, .-uart_getline
 
 
-.bss
+	.bss
 	
-.align 8
-.comm uart_input_buffer, BUFFER_SIZE
-.size uart_input_buffer, BUFFER_SIZE
+	.align 8
+	.comm uart_input_buffer, BUFFER_SIZE
+	.size uart_input_buffer, BUFFER_SIZE
 

--- a/vmon-format.el
+++ b/vmon-format.el
@@ -1,0 +1,7 @@
+(defun vmon-format-function ()
+  "Format the whole buffer."
+  (setq tab-width 4)
+  (indent-region (point-min) (point-max) nil)
+  (tabify (point-min) (point-max))
+  (save-buffer)
+)

--- a/vmon-format.sh
+++ b/vmon-format.sh
@@ -1,0 +1,32 @@
+ #!/bin/sh
+if [ $# -eq 0 ]
+then
+  echo "vmon-format.sh requires at least one argument." 1>&2
+  echo "Usage: vmon-format.sh files-to-indent" 1>&2
+  exit 1
+fi
+
+while [ $# -ge 1 ]
+do
+  if [ -d $1 ]
+  then
+    echo "Argument of vmon-format.sh $1 cannot be a directory." 1>&2
+    exit 1
+  fi
+
+  # Check for existence of file:
+  ls $1 2>/dev/null | grep $1 > /dev/null
+  if [ $? != 0 ]
+  then
+    echo "vmon-format.sh: $1 not found." 1>&2
+    exit 1
+  fi
+
+  echo "Indenting $1 with emacs in batch mode"
+  #  emacs -batch $1 -l ~/bin/emacs-format-file -f emacs-format-function
+  emacs -batch $1 -l ~/src/riscv/vmon/vmon-format.el -f vmon-format-function
+  echo
+  shift 1
+done
+
+exit 0


### PR DESCRIPTION
- Format assembly source files with 4-space tabs
- Add makefile target and script to reformat source if spaces ever come back