### PR TITLE
Implement fb, fh, fw commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,14 @@ disassemble from <start_addr> to <end_addr>
 continue disassembly from last address used
 
 **f <start_addr> <end_addr> <byte_value>**
+**fb <start_addr> <end_addr> <byte_value>** 
 find <byte_value> in memory from <start_addr> to <end_addr>
+
+**fh <start_addr> <end_addr> <16bit_value>**
+find <16bit_value> in memory from <start_addr> to <end_addr>
+
+**fw <start_addr> <end_addr> <32bit_value>**
+find <32bit_value> in memory from <start_addr> to <end_addr>
 
 **g <start_addr>**
 start program execution at <start_addr>

--- a/src/cmd_F.S
+++ b/src/cmd_F.S
@@ -7,9 +7,27 @@
 
 .text
 
-
 cmd_F:
-	# read src_start from text buffer	
+	li		t3, 1						# size to look for (1, 2, 4 bytes)
+	lb		t1, 0(a0)					# read byte following f
+	addi	a0, a0, 1
+	li		t0, 'b'
+	beq		t0, t1, cmd_F_find_b
+	li		t0, 'h'
+	beq		t0, t1, cmd_F_find_h
+	li		t0, 'w'
+	beq		t0, t1, cmd_F_find_w
+	addi	a0, a0, -1
+cmd_F_find_b:
+	li		s0, 1
+	j	cmd_F_read_start
+cmd_F_find_h:
+	li		s0, 2
+	j	cmd_F_read_start
+cmd_F_find_w:
+	li		s0, 4
+cmd_F_read_start:
+	# read src_start from text buffer
 	jal		skip_whitespace
 	jal		get_hex_addr				# read start_addr from text buffer
 	bnez	a2, cmd_F_error				# abort command if not found
@@ -19,17 +37,35 @@ cmd_F:
 	jal		get_hex_addr				# read end_addr from text buffer
 	bnez	a2, cmd_F_error				# abort command if not found
 	mv		a4, a1
-	# read byte_value from text buffer
+	# read search value from text buffer
 	jal		skip_whitespace
-	jal		get_hex_addr			
+	jal		get_hex_addr
 	bnez	a2, cmd_F_error				# abort command if not found
 	mv		a5, a1
 
+	# XXX: ensure no overflow of 8, 16, 32 value?
+
 	# a3: src_start
 	# a4: src_end
+	# a5: value to search for
 
 cmd_F_loop_forward:
-	lb		t0, 0(a3)
+	li		t4, 1
+	bne		s0, t4, cmd_F_loop_h
+	lbu		t0, 0(a3)
+	j		cmd_F_compare
+cmd_F_loop_h:
+	li		t4, 2
+	bne		s0, t4, cmd_F_loop_w
+	lhu		t0, 0(a3)
+	j		cmd_F_compare
+cmd_F_loop_w:
+#if	XLEN == 32
+	lw		t0, 0(a3)
+#else
+	lwu		t0, 0(a3)
+#endif
+cmd_F_compare:
 	beq		t0, a5, cmd_F_found
 	addi	a3, a3, 1
 	bgt		a3, a4, cmd_F_done

--- a/src/cmd_H.S
+++ b/src/cmd_H.S
@@ -24,6 +24,9 @@ string_help:
 	d <start_addr> <end_addr> - disassemble from start_addr to end_addr\n\
 	d - continue disassembly from last address\n\
 	f <start_addr> <end_addr> <byte_value> - find byte value\n\
+	fb <start_addr> <end_addr> <byte_value> - find byte value\n\
+	fh <start_addr> <end_addr> <16bit_value> - find 16bit value\n\
+	fw <start_addr> <end_addr> <32bit_value> - find 32bit value\n\
 	g <start_addr> - go to start_addr\n\
 	h - help\n\
 	i - print segment and debugging information\n\

--- a/src/cmd_H.S
+++ b/src/cmd_H.S
@@ -35,6 +35,9 @@ string_help:
 	m - continue memory dump from last address\n\
 	p <dst_addr> <byte_value0> [...] - write byte_value(s) starting at dst_addr\n\
 	x - exit to caller\n\
+	/h <hex_value> base conversion from hex\n\
+	/d <dec_value> base conversion from decimal\n\
+	/b <bin_value> base conversion from binary\n\
 	All address and value entries are in hex (without 0x prefix).\n"
 .size string_help, .-string_help
 

--- a/src/cmd_SLASH.S
+++ b/src/cmd_SLASH.S
@@ -9,8 +9,6 @@
 
 
 cmd_SLASH:
-	addi	sp, sp, -(XLEN_BYTES*1) # Don't need to save ra here as we are part of mainloop.
-	SAVE_X	s0, 0(sp)
     lb		t1, 0(a0)	# read byte following 'B'
 	addi	a0, a0, 1
 	li		t0, 'h'
@@ -59,8 +57,6 @@ cmd_slash_display:
 	jal		print_binary
 	jal		print_newline
 cmd_slash_end:
-	LOAD_X	s0, 0(sp)
-	addi	sp, sp, (XLEN_BYTES*1)
 	j		main_prompt
 
 string_info_hex:

--- a/src/parse.S
+++ b/src/parse.S
@@ -20,12 +20,12 @@ skip_whitespace:
 	li		t1, '\t'
 skip_whitespace_next:
 	lb		t2, 0(a0)				# get byte from buffer
-	beq		t2, t0, skip_whitespace_advance 
+	beq		t2, t0, skip_whitespace_advance
 	beq		t2, t1, skip_whitespace_advance
 	j		skip_whitespace_done
 skip_whitespace_advance:
 	addi	a0, a0, 1				# advance buffer pointer
-	j		skip_whitespace_next	
+	j		skip_whitespace_next
 skip_whitespace_done:
 	ret
 .size skip_whitespace, .-skip_whitespace
@@ -57,7 +57,7 @@ find_insn_name_end:
 	bgt		t0, t1, find_insn_name_end_done
 find_insn_name_end_valid_char:
 	addi	a0, a0, 1
-	j		find_insn_name_end	  
+	j		find_insn_name_end
 find_insn_name_end_done:
 	ret
 .size find_insn_name_end, .-find_insn_name_end
@@ -78,7 +78,7 @@ find_register_name_end:
 	bge		t0, t1, find_register_name_end_valid_char
 find_register_name_end_valid_char:
 	addi	a0, a0, 1
-	j		find_register_name_end	  
+	j		find_register_name_end
 find_register_name_end_done:
 	addi	a0, a0, -1
 	ret
@@ -162,9 +162,9 @@ parse_binary_return_error:
 # out: parsed binary number in a1
 # out: error code in a2 (OK=0)
 parse_decimal:
-    li		a2, -1 # error code
-    li		a1, 0  # result
-    li		t3, 0  # digit found flag
+	li		a2, -1 # error code
+	li		a1, 0  # result
+	li		t3, 0  # digit found flag
 	li		t6, 0  # negative flag
 
 	# check for negative number
@@ -181,40 +181,40 @@ parse_decimal_plus:
 	addi	a0, a0, 1
 
 parse_decimal_loop:
-    lb		t0, 0(a0)      
-    addi	t1, t0, -'0'  # potential digit value
-    sltiu	t2, t1, 10    # is potential digit 0-9? (t2=1 if yes)
-    beqz	t2, parse_decimal_check_term # if not 0-9
+	lb		t0, 0(a0)
+	addi	t1, t0, -'0'  # potential digit value
+	sltiu	t2, t1, 10	  # is potential digit 0-9? (t2=1 if yes)
+	beqz	t2, parse_decimal_check_term # if not 0-9
 
 	# have a valid decimal digit, multiply accumulator by 10
 	# and add in the new digit value.
-    li		t3, 1
-    # a1 = a1 * 10
-    slli	t4, a1, 3      # t4 = a1 * 8
-    slli	t5, a1, 1      # t5 = a1 * 2
-    add		a1, t5, t4     # a1 = a1 * 10
-    # a1 = a1 + digit_value
-    add		a1, a1, t1
-    addi	a0, a0, 1      # ptr++
-    j		parse_decimal_loop
+	li		t3, 1
+	# a1 = a1 * 10
+	slli	t4, a1, 3	   # t4 = a1 * 8
+	slli	t5, a1, 1	   # t5 = a1 * 2
+	add		a1, t5, t4	   # a1 = a1 * 10
+	# a1 = a1 + digit_value
+	add		a1, a1, t1
+	addi	a0, a0, 1	   # ptr++
+	j		parse_decimal_loop
 
 parse_decimal_check_term:
-    # Check terminators (' ' or ASCII_RETURN)
-    li		t1, ' '
-    beq		t0, t1, parse_decimal_check_flag
-    li		t1, ASCII_RETURN
-    beq		t0, t1, parse_decimal_check_flag
-    # Invalid char: Jump to return (a2 is already -1)
-    j		parse_decimal_final_return
+	# Check terminators (' ' or ASCII_RETURN)
+	li		t1, ' '
+	beq		t0, t1, parse_decimal_check_flag
+	li		t1, ASCII_RETURN
+	beq		t0, t1, parse_decimal_check_flag
+	# Invalid char: Jump to return (a2 is already -1)
+	j		parse_decimal_final_return
 
 parse_decimal_check_flag:
-    beqz	t3, parse_decimal_final_return # If t3=0, error (a2 is -1)
+	beqz	t3, parse_decimal_final_return # If t3=0, error (a2 is -1)
 	# apply sign, if necessary
 	beqz	t6, parse_decimal_set_success
 	sub		a1, x0, a1 # 2's complement negation
 parse_decimal_set_success:
-    li		a2, 0
+	li		a2, 0
 parse_decimal_final_return:
-    ret
+	ret
 
 .size parse_decimal, .-parse_decimal


### PR DESCRIPTION
Allows one to search for 8, 16, and 32-bit unsigned quantities (note, former code searched for signed quantities, which I believe was a bug; like if you searched for 0x80, that would get sign extended to 0xFFFFF...FF80 which would be byte compared, and so would never match a byte value as comparison was done without a mask of 0xff. Seemed easiest to just do unsigned and avoid sign extension)

The f command is a synonym for fb.